### PR TITLE
Apply defaults to objects implementing CustomDefaulter

### DIFF
--- a/internal/resources/resource_with_empty_status.go
+++ b/internal/resources/resource_with_empty_status.go
@@ -17,11 +17,15 @@ limitations under the License.
 package resources
 
 import (
+	"context"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-var _ webhook.Defaulter = &TestResourceEmptyStatus{}
+var _ webhook.CustomDefaulter = &TestResourceEmptyStatus{}
 
 // +kubebuilder:object:root=true
 // +genclient
@@ -34,11 +38,18 @@ type TestResourceEmptyStatus struct {
 	Status TestResourceEmptyStatusStatus `json:"status"`
 }
 
-func (r *TestResourceEmptyStatus) Default() {
+func (*TestResourceEmptyStatus) Default(ctx context.Context, obj runtime.Object) error {
+	r, ok := obj.(*TestResourceEmptyStatus)
+	if !ok {
+		return fmt.Errorf("expected obj to be TestResourceEmptyStatus")
+	}
+
 	if r.Spec.Fields == nil {
 		r.Spec.Fields = map[string]string{}
 	}
 	r.Spec.Fields["Defaulter"] = "ran"
+
+	return nil
 }
 
 // +kubebuilder:object:generate=true

--- a/internal/resources/resource_with_unexported_fields.go
+++ b/internal/resources/resource_with_unexported_fields.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -32,9 +33,9 @@ import (
 )
 
 var (
-	_ webhook.Defaulter = &TestResourceUnexportedFields{}
-	_ webhook.Validator = &TestResourceUnexportedFields{}
-	_ client.Object     = &TestResourceUnexportedFields{}
+	_ webhook.CustomDefaulter = &TestResourceUnexportedFields{}
+	_ webhook.CustomValidator = &TestResourceUnexportedFields{}
+	_ client.Object           = &TestResourceUnexportedFields{}
 )
 
 // +kubebuilder:object:root=true
@@ -48,26 +49,51 @@ type TestResourceUnexportedFields struct {
 	Status TestResourceUnexportedFieldsStatus `json:"status"`
 }
 
-func (r *TestResourceUnexportedFields) Default() {
+func (*TestResourceUnexportedFields) Default(ctx context.Context, obj runtime.Object) error {
+	r, ok := obj.(*TestResourceUnexportedFields)
+	if !ok {
+		return fmt.Errorf("expected obj to be TestResourceUnexportedFields")
+	}
 	if r.Spec.Fields == nil {
 		r.Spec.Fields = map[string]string{}
 	}
 	r.Spec.Fields["Defaulter"] = "ran"
+
+	return nil
 }
 
-func (r *TestResourceUnexportedFields) ValidateCreate() (admission.Warnings, error) {
-	return nil, r.validate().ToAggregate()
+func (*TestResourceUnexportedFields) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	r, ok := obj.(*TestResourceUnexportedFields)
+	if !ok {
+		return nil, fmt.Errorf("expected obj to be TestResourceUnexportedFields")
+	}
+
+	return nil, r.validate(ctx).ToAggregate()
 }
 
-func (r *TestResourceUnexportedFields) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
-	return nil, r.validate().ToAggregate()
+func (*TestResourceUnexportedFields) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	_, ok := oldObj.(*TestResourceUnexportedFields)
+	if !ok {
+		return nil, fmt.Errorf("expected oldObj to be TestResourceUnexportedFields")
+	}
+	r, ok := newObj.(*TestResourceUnexportedFields)
+	if !ok {
+		return nil, fmt.Errorf("expected newObj to be TestResourceUnexportedFields")
+	}
+
+	return nil, r.validate(ctx).ToAggregate()
 }
 
-func (r *TestResourceUnexportedFields) ValidateDelete() (admission.Warnings, error) {
+func (*TestResourceUnexportedFields) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	_, ok := obj.(*TestResourceUnexportedFields)
+	if !ok {
+		return nil, fmt.Errorf("expected obj to be TestResourceUnexportedFields")
+	}
+
 	return nil, nil
 }
 
-func (r *TestResourceUnexportedFields) validate() field.ErrorList {
+func (r *TestResourceUnexportedFields) validate(ctx context.Context) field.ErrorList {
 	errs := field.ErrorList{}
 
 	if r.Spec.Fields != nil {

--- a/reconcilers/resource.go
+++ b/reconcilers/resource.go
@@ -269,7 +269,12 @@ func (r *ResourceReconciler[T]) reconcileOuter(ctx context.Context, req Request)
 	}
 	resource := originalResource.DeepCopyObject().(T)
 
-	if defaulter, ok := client.Object(resource).(webhook.Defaulter); ok {
+	if defaulter, ok := client.Object(resource).(webhook.CustomDefaulter); ok {
+		// resource.Default(ctx, resource)
+		if err := defaulter.Default(ctx, resource); err != nil {
+			return Result{}, err
+		}
+	} else if defaulter, ok := client.Object(resource).(webhook.Defaulter); ok {
 		// resource.Default()
 		defaulter.Default()
 	}

--- a/reconcilers/webhook.go
+++ b/reconcilers/webhook.go
@@ -207,7 +207,12 @@ func (r *AdmissionWebhookAdapter[T]) reconcile(ctx context.Context, req admissio
 		return err
 	}
 
-	if defaulter, ok := client.Object(resource).(webhook.Defaulter); ok {
+	if defaulter, ok := client.Object(resource).(webhook.CustomDefaulter); ok {
+		// resource.Default(ctx, resource)
+		if err := defaulter.Default(ctx, resource); err != nil {
+			return err
+		}
+	} else if defaulter, ok := client.Object(resource).(webhook.Defaulter); ok {
 		// resource.Default()
 		defaulter.Default()
 	}


### PR DESCRIPTION
The controller-runtime Defaulter interface is deprecated in favor of CustomDefaulter. We now detect either interface and apply it to implementing objects.