### PR TITLE
Type safe stashing of context values

### DIFF
--- a/reconcilers/stash.go
+++ b/reconcilers/stash.go
@@ -57,7 +57,7 @@ func ClearValue(ctx context.Context, key StashKey) interface{} {
 	return value
 }
 
-// Stasher stores and retrieves values from the stash context. The context must be configured
+// Stasher stores and retrieves values from the stash context. The context which gets passed to its methods must be configured
 // with a stash via WithStash(). The stash is pre-configured for the context within a reconciler.
 type Stasher[T any] interface {
 	// Key is the stash key used to store and retrieve the value


### PR DESCRIPTION
Introducing a Stasher which is a convenience helper for interacting with typed values for a single stash key. The stasher itself is generic and handles casting retrieved values to the desired type.

There are three different ways to handle the value not existing or being of the wrong type:

- RetrieveOrDie panics if a value of the desired type is not found
- RetrieveOrError errors if a value of the desired type is not found
- RetrieveOrEmpty falls back to the empty value for the type