### PR TITLE
ForEach reconciler

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,13 +538,13 @@ func TenTimesReconciler() *reconcilers.SubReconciler[*buildv1alpha1.Function] {
 
 #### ForEach
 
-A [`ForEach`](https://pkg.go.dev/reconciler.io/runtime/reconcilers#ForEach) calls the reconciler for each item returned from Items. The current cursor can be retrieved with [`CursorStasher`](https://pkg.go.dev/reconciler.io/runtime/reconcilers#CursorStasher).
+A [`ForEach`](https://pkg.go.dev/reconciler.io/runtime/reconcilers#ForEach) calls the reconciler for each item returned from Items. A cursor marks the item being reconciled. The current cursor can be retrieved with [`CursorStasher`](https://pkg.go.dev/reconciler.io/runtime/reconcilers#CursorStasher).
 
-Nested iteration is allowed so long as the types being iterated over contain unique names. Otherwise the stash keys will collide. For testing the nested reconciler outside the scope of the loop, use the stasher's Key method to lookup the StashKey, do not expect the StashKey to be stable between releases.
+Nested iteration is allowed so long as the types being iterated over contain unique names. Otherwise the stash keys will collide. For testing the nested reconciler outside the scope of the loop, use the CursorStasher's Key method to lookup the StashKey, do not expect the StashKey to be stable between releases.
 
 **Example:**
 
-A ForEach can be used interact with each volume mount on a pod. 
+A ForEach can be used to interact with each volume mount on a pod. 
 
 ```go
 func VolumeMountReconciler() *reconcilers.SubReconciler[*corev1.Pod] {

--- a/reconcilers/flow.go
+++ b/reconcilers/flow.go
@@ -286,7 +286,7 @@ func (r *While[T]) Reconcile(ctx context.Context, resource T) (Result, error) {
 // Cursor that is available via the CursorStasher helper. Multiple ForEach reconcilers are nestable
 // so long as the types being iterated over are unique.
 type ForEach[Type client.Object, Item any] struct {
-	// Name used to identify this reconciler.  Defaults to `ForEach`.  Ideally unique, but
+	// Name used to identify this reconciler.  Defaults to `ForEach`. Ideally unique, but
 	// not required to be so.
 	//
 	// +optional
@@ -380,7 +380,7 @@ type Cursor[I any] struct {
 	Item I
 }
 
-// CursorStasher creates a Stasher for an Cursor of the generic type
+// CursorStasher creates a Stasher for a Cursor of the generic type
 func CursorStasher[I any]() Stasher[Cursor[I]] {
 	// avoid key collisions for nested iteration over different types
 	var empty I

--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -174,7 +174,6 @@ func typeName(i interface{}) string {
 	}
 
 	t := reflect.TypeOf(i)
-	// TODO do we need this?
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}


### PR DESCRIPTION
The ForEach reconciler can iterator over a slice calling a nested reconciler for each item. The current item is stashed on the context to be retrieved with a CursorStasher.

Nested iterators are allowed so long as the type of the items being iterated over have unique names. We may enhance the generated stash key in the future to relax this requirement, so users should not assume the specific key to be stable between releases.