### PR TITLE
Drop deprecated ResourceManager APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,7 +1137,7 @@ Use a provided ObjectManager or define a custom strategy to change specific beha
 <a name="resourcemanager">
 #### UpdatingObjectManager
 
-The [`UpdatingObjectManager`](https://pkg.go.dev/reconciler.io/runtime/reconcilers#UpdatingObjectManager) (previously [`ResourceManager`](https://pkg.go.dev/reconciler.io/runtime/reconcilers#ResourceManager)) uses the `client.Client#{Create, Update, Delete}` methods to synchronize state to the API Server.
+The [`UpdatingObjectManager`](https://pkg.go.dev/reconciler.io/runtime/reconcilers#UpdatingObjectManager) (previously [`ResourceManager`](https://pkg.go.dev/reconciler.io/runtime@v0.21.0/reconcilers#ResourceManager)) uses the `client.Client#{Create, Update, Delete}` methods to synchronize state to the API Server.
 
 Internally, a mutations made to the resource at admission time (like defaults applied by a mutating webhook) are captured and reapplied to the desired state before checking if an update is needed. This reduces requests that are functionally a no-op but create churn on the API Server. The mutation cache is defensive and fails open to make an API request.
 
@@ -1163,10 +1163,6 @@ reconciler.io runtime is rapidly evolving. While we strive for API compatability
 
 Backwards support may be removed in a future release, users are encouraged to migrate.
 
-- `ResourceManager` is deprecated in favor of `ObjectManager` for a generic type, or `UpdatingObjectManager`.
-- `AggregateReconciler.{HarmonizeImmutableFields, MergeBeforeUpdate, Sanitize}` are deprecated in favor of `AggregateReconciler.AggregateObjectManager`.
-- `ChildReconciler.{Finalizer, HarmonizeImmutableFields, MergeBeforeUpdate, Sanitize, SetResourceManager}` are deprecated in favor of `ChildReconciler.ChildObjectManager`.
-- `ChildSetReconciler.{HarmonizeImmutableFields, MergeBeforeUpdate, Sanitize}` are deprecated in favor of `ChildSetReconciler.ChildObjectManager`.
 - status `InitializeConditions()` is deprecated in favor of `InitializeConditions(context.Context)`.
 - `ConditionSet#Manage` is deprecated in favor of `ConditionSet#ManageWithContext`.
 - `HaltSubReconcilers` is deprecated in favor of `ErrHaltSubReconcilers`.

--- a/README.md
+++ b/README.md
@@ -982,7 +982,7 @@ func StashExampleSubReconciler(c reconcilers.Config) reconcilers.SubReconciler[*
 		Name: "StashExample",
 		Sync: func(ctx context.Context, resource *examplev1.MyExample) error {
 			value, err := exampleStasher.RetrieveOrError(ctx)
-			if err == reconcilers.ErrStashValueNotFound {
+			if err != nil {
 				return nil, fmt.Errorf("%w for key %q", err, exampleStasher.Key())
 			}
 			... // do something with the value

--- a/internal/util.go
+++ b/internal/util.go
@@ -20,6 +20,9 @@ import "reflect"
 
 // IsNil returns true if the value is nil, false if the value is not nilable or not nil
 func IsNil(val interface{}) bool {
+	if val == nil {
+		return true
+	}
 	if !IsNilable(val) {
 		return false
 	}

--- a/reconcilers/objectmanager_test.go
+++ b/reconcilers/objectmanager_test.go
@@ -20,15 +20,441 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	diecorev1 "reconciler.io/dies/apis/core/v1"
+	diemetav1 "reconciler.io/dies/apis/meta/v1"
+	"reconciler.io/runtime/apis"
+	"reconciler.io/runtime/internal/resources"
+	"reconciler.io/runtime/internal/resources/dies"
 	"reconciler.io/runtime/reconcilers"
+	rtesting "reconciler.io/runtime/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func TestUpdatingObjectManager(t *testing.T) {
+	testNamespace := "test-namespace"
+	testName := "test-resource"
+	testFinalizer := "test-finalizer"
+
+	scheme := runtime.NewScheme()
+	_ = resources.AddToScheme(scheme)
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	now := metav1.Time{Time: time.Now().Truncate(time.Second)}
+
+	resource := dies.TestResourceBlank.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Namespace(testNamespace)
+			d.Name(testName)
+		}).
+		StatusDie(func(d *dies.TestResourceStatusDie) {
+			d.ConditionsDie(
+				diemetav1.ConditionBlank.Type(apis.ConditionReady).Status(metav1.ConditionUnknown).Reason("Initializing"),
+			)
+		})
+
+	desiredConfigMap := diecorev1.ConfigMapBlank.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Name(testName)
+			d.Namespace(testNamespace)
+		}).
+		AddData("hello", "world")
+	givenConfigMap := desiredConfigMap.MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+		d.CreationTimestamp(now)
+	})
+
+	makeUpdatingObjectManager := func(modifiers ...func(*reconcilers.UpdatingObjectManager[*corev1.ConfigMap])) *reconcilers.UpdatingObjectManager[*corev1.ConfigMap] {
+		om := &reconcilers.UpdatingObjectManager[*corev1.ConfigMap]{
+			MergeBeforeUpdate: func(current, desired *corev1.ConfigMap) {
+				current.Labels = desired.Labels
+				current.Data = desired.Data
+			},
+		}
+		for i := range modifiers {
+			modifiers[i](om)
+		}
+		return om
+	}
+	withFinalizer := func(finalizer string) func(*reconcilers.UpdatingObjectManager[*corev1.ConfigMap]) {
+		return func(om *reconcilers.UpdatingObjectManager[*corev1.ConfigMap]) {
+			om.Finalizer = finalizer
+		}
+	}
+	withTrackDesired := func(trackDesired bool) func(*reconcilers.UpdatingObjectManager[*corev1.ConfigMap]) {
+		return func(om *reconcilers.UpdatingObjectManager[*corev1.ConfigMap]) {
+			om.TrackDesired = trackDesired
+		}
+	}
+	withHarmonizeImmutableFields := func(harmonizeImmutableFields func(*corev1.ConfigMap, *corev1.ConfigMap)) func(*reconcilers.UpdatingObjectManager[*corev1.ConfigMap]) {
+		return func(om *reconcilers.UpdatingObjectManager[*corev1.ConfigMap]) {
+			om.HarmonizeImmutableFields = harmonizeImmutableFields
+		}
+	}
+
+	actualStashKey := rtesting.ObjectManagerReconcilerTestHarnessActualStasher[*corev1.ConfigMap]().Key()
+	desiredStashKey := rtesting.ObjectManagerReconcilerTestHarnessDesiredStasher[*corev1.ConfigMap]().Key()
+	resultStashKey := rtesting.ObjectManagerReconcilerTestHarnessResultStasher[*corev1.ConfigMap]().Key()
+
+	rts := rtesting.SubReconcilerTests[client.Object]{
+		"in sync": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey:  givenConfigMap.DieReleasePtr(),
+				desiredStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: givenConfigMap.DieReleasePtr(),
+			},
+		},
+		"missing and desired": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey:  nil,
+				desiredStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created", `Created ConfigMap %q`, testName),
+			},
+			ExpectCreates: []client.Object{
+				desiredConfigMap,
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+		},
+		"missing and desired, blank actual": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey:  diecorev1.ConfigMapBlank.DieDefaultTypeMetadata().DieReleasePtr(),
+				desiredStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created", `Created ConfigMap %q`, testName),
+			},
+			ExpectCreates: []client.Object{
+				desiredConfigMap,
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+		},
+		"missing and desired, errored": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey:  nil,
+				desiredStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("create", "ConfigMap"),
+			},
+			ShouldErr: true,
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "CreationFailed", `Failed to create ConfigMap %q: inducing failure for create ConfigMap`, testName),
+			},
+			ExpectCreates: []client.Object{
+				desiredConfigMap,
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: nil,
+			},
+		},
+		"correct drift": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey: givenConfigMap.
+					AddData("foo", "bar").
+					DieReleasePtr(),
+				desiredStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Updated", `Updated ConfigMap %q`, testName),
+			},
+			ExpectUpdates: []client.Object{
+				desiredConfigMap,
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+		},
+		"correct drift, errored": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey: givenConfigMap.
+					AddData("foo", "bar").
+					DieReleasePtr(),
+				desiredStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("update", "ConfigMap"),
+			},
+			ShouldErr: true,
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "UpdateFailed", `Failed to update ConfigMap %q: inducing failure for update ConfigMap`, testName),
+			},
+			ExpectUpdates: []client.Object{
+				desiredConfigMap,
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: nil,
+			},
+		},
+		"cleanup": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey: givenConfigMap.
+					AddData("foo", "bar").
+					DieReleasePtr(),
+				desiredStashKey: nil,
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Deleted", `Deleted ConfigMap %q`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(givenConfigMap, scheme),
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: nil,
+			},
+		},
+		"cleanup, errored": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey: givenConfigMap.
+					AddData("foo", "bar").
+					DieReleasePtr(),
+				desiredStashKey: nil,
+			},
+			WithReactors: []rtesting.ReactionFunc{
+				rtesting.InduceFailure("delete", "ConfigMap"),
+			},
+			ShouldErr: true,
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeWarning, "DeleteFailed", `Failed to delete ConfigMap %q: inducing failure for delete ConfigMap`, testName),
+			},
+			ExpectDeletes: []rtesting.DeleteRef{
+				rtesting.NewDeleteRefFromObject(givenConfigMap, scheme),
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: nil,
+			},
+		},
+		"in sync with finalizer": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer)
+				}).
+				DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(
+					withFinalizer(testFinalizer),
+				),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey:  givenConfigMap.DieReleasePtr(),
+				desiredStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: givenConfigMap.DieReleasePtr(),
+			},
+		},
+		"in sync missing finalizer": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(
+					withFinalizer(testFinalizer),
+				),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey:  givenConfigMap.DieReleasePtr(),
+				desiredStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+			ExpectResource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer)
+					d.ResourceVersion("1000")
+				}).
+				DieReleasePtr(),
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched", `Patched finalizer %q`, testFinalizer),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:       "testing.reconciler.runtime",
+					Kind:        "TestResource",
+					Namespace:   testNamespace,
+					Name:        testName,
+					SubResource: "",
+					PatchType:   types.MergePatchType,
+					Patch:       []byte(`{"metadata":{"finalizers":["test-finalizer"],"resourceVersion":"999"}}`),
+				},
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: givenConfigMap.DieReleasePtr(),
+			},
+		},
+		"cleanup finalizer": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers(testFinalizer)
+				}).
+				DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(
+					withFinalizer(testFinalizer),
+				),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey:  nil,
+				desiredStashKey: nil,
+			},
+			ExpectResource: resource.
+				MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+					d.Finalizers()
+					d.ResourceVersion("1000")
+				}).
+				DieReleasePtr(),
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "FinalizerPatched", `Patched finalizer %q`, testFinalizer),
+			},
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:       "testing.reconciler.runtime",
+					Kind:        "TestResource",
+					Namespace:   testNamespace,
+					Name:        testName,
+					SubResource: "",
+					PatchType:   types.MergePatchType,
+					Patch:       []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
+				},
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: nil,
+			},
+		},
+		"track given": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(
+					withTrackDesired(true),
+				),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey:  givenConfigMap.DieReleasePtr(),
+				desiredStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(givenConfigMap, resource, scheme),
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: givenConfigMap.DieReleasePtr(),
+			},
+		},
+		"track generated names": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(
+					withTrackDesired(true),
+				),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey: nil,
+				desiredStashKey: desiredConfigMap.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Name("")
+						d.GenerateName(testName + "-")
+					}).
+					DieReleasePtr(),
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(givenConfigMap.MetadataDie(func(d *diemetav1.ObjectMetaDie) { d.Name(testName + "-001") }), resource, scheme),
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(resource, scheme, corev1.EventTypeNormal, "Created", `Created ConfigMap %q`, testName+"-001"),
+			},
+			ExpectCreates: []client.Object{
+				desiredConfigMap.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Name("")
+						d.GenerateName(testName + "-")
+					}),
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: desiredConfigMap.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Name(testName + "-001")
+						d.GenerateName(testName + "-")
+					}).
+					DieReleasePtr(),
+			},
+		},
+		"ignore drift in immutable fields": rtesting.SubReconcilerTestCase[client.Object]{
+			Resource: resource.DieReleasePtr(),
+			Metadata: map[string]any{
+				"ObjectManager": makeUpdatingObjectManager(
+					withHarmonizeImmutableFields(func(actual, desired *corev1.ConfigMap) {
+						if actual.Immutable != nil && *actual.Immutable {
+							// data is immutable, align desired with actual
+							desired.Data = actual.Data
+						}
+					}),
+				),
+			},
+			GivenStashedValues: map[reconcilers.StashKey]any{
+				actualStashKey: givenConfigMap.
+					Immutable(ptr.To[bool](true)).
+					AddData("foo", "bar").
+					DieReleasePtr(),
+				desiredStashKey: desiredConfigMap.DieReleasePtr(),
+			},
+			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+				resultStashKey: givenConfigMap.
+					Immutable(ptr.To[bool](true)).
+					AddData("foo", "bar").
+					DieReleasePtr(),
+			},
+		},
+	}
+
+	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase[client.Object], c reconcilers.Config) reconcilers.SubReconciler[client.Object] {
+		return &rtesting.ObjectManagerReconcilerTestHarness[*corev1.ConfigMap]{
+			ObjectManager: rtc.Metadata["ObjectManager"].(reconcilers.ObjectManager[*corev1.ConfigMap]),
+		}
+	})
+
+}
 
 func TestPatch(t *testing.T) {
 	tests := []struct {

--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -54,9 +54,6 @@ var (
 	//
 	// See documentation for the specific SubReconciler caller to see how they handle this case.
 	ErrHaltSubReconcilers = fmt.Errorf("stop processing SubReconcilers, without returning an error: %w", ErrQuiet)
-
-	// Deprecated HaltSubReconcilers use ErrHaltSubReconcilers instead
-	HaltSubReconcilers = ErrHaltSubReconcilers
 )
 
 const requestStashKey StashKey = "reconciler.io/runtime:request"

--- a/reconcilers/resource_test.go
+++ b/reconcilers/resource_test.go
@@ -1078,7 +1078,7 @@ func TestResourceReconciler(t *testing.T) {
 								resource.Status.Fields = map[string]string{
 									"want": "this to run",
 								}
-								return reconcilers.HaltSubReconcilers
+								return reconcilers.ErrHaltSubReconcilers
 							},
 						},
 						&reconcilers.SyncReconciler[*resources.TestResource]{

--- a/testing/objectmanager.go
+++ b/testing/objectmanager.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2024 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	"reconciler.io/runtime/internal"
+	"reconciler.io/runtime/reconcilers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ reconcilers.ObjectManager[client.Object] = (*StubObjectManager[client.Object])(nil)
+
+type StubObjectManager[Type client.Object] struct{}
+
+func (m *StubObjectManager[T]) SetupWithManager(ctx context.Context, mgr ctrl.Manager, bldr *builder.Builder) error {
+	return nil
+}
+
+func (m *StubObjectManager[T]) Manage(ctx context.Context, resource client.Object, actual, desired T) (T, error) {
+	var nilT T
+	c := reconcilers.RetrieveConfigOrDie(ctx)
+
+	if (internal.IsNil(actual) || actual.GetCreationTimestamp().Time.IsZero()) && internal.IsNil(desired) {
+		// nothing to do
+		return nilT, nil
+	}
+	if internal.IsNil(desired) {
+		current := actual.DeepCopyObject().(T)
+		if current.GetDeletionTimestamp() != nil {
+			// object is already terminating
+			return nilT, nil
+		}
+		if err := c.Delete(ctx, current); err != nil {
+			return nilT, err
+		}
+		return nilT, nil
+	}
+	if internal.IsNil(actual) || actual.GetCreationTimestamp().Time.IsZero() {
+		current := desired.DeepCopyObject().(T)
+		if err := c.Create(ctx, current); err != nil {
+			return nilT, err
+		}
+		return current, nil
+	}
+	current := actual.DeepCopyObject().(T)
+	// merge desired into current
+	m.unsafeMergeInto(current, desired)
+	if !equality.Semantic.DeepEqual(actual, current) {
+		if err := c.Update(ctx, current); err != nil {
+			return nilT, err
+		}
+		return current, nil
+	}
+
+	return current, nil
+}
+
+func (m *StubObjectManager[T]) unsafeMergeInto(target, source T) {
+	ut, err := runtime.DefaultUnstructuredConverter.ToUnstructured(target)
+	if err != nil {
+		panic(err)
+	}
+	us, err := runtime.DefaultUnstructuredConverter.ToUnstructured(source)
+	if err != nil {
+		panic(err)
+	}
+
+	// copy allowed top-level fields
+	for k := range us {
+		if k != "apiVersion" && k != "kind" && k != "metadata" && k != "status" {
+			ut[k] = us[k]
+		}
+	}
+
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(ut, target); err != nil {
+		panic(err)
+	}
+
+	// copy allowed metadata fields
+	target.SetAnnotations(source.GetAnnotations())
+	target.SetLabels(source.GetLabels())
+}

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -175,6 +175,9 @@ func (tc *SubReconcilerTestCase[T]) Run(t *testing.T, scheme *runtime.Scheme, fa
 	// Set func for verifying stashed values
 	if tc.VerifyStashedValue == nil {
 		tc.VerifyStashedValue = func(t *testing.T, key reconcilers.StashKey, expected, actual interface{}) {
+			if internal.IsNil(expected) && internal.IsNil(actual) {
+				return
+			}
 			if diff := cmp.Diff(expected, actual, reconcilers.IgnoreAllUnexported, IgnoreLastTransitionTime, IgnoreTypeMeta, IgnoreCreationTimestamp, IgnoreResourceVersion, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("ExpectStashedValues[%q] differs (%s, %s): %s", key, DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 			}


### PR DESCRIPTION
Drops deprecated APIs for `ResourceManager`, and migrates tests from the `ChildReconciler` to the `UpdatingObjectManager`. This was a holdover from before `ResouceManager` was extracted from `ChildReconciler`.

The `StubObjectManager` is useful for testing a reconciler that needs to interact with an `ObjectManager`. It will preform a basic create/update/delete and nothing else.

The `ObjectManagerReconcilerTestHarness` is useful for testing a custom `ObjectManager` in the context of a reconciler test case. The actual, expected and result objects are stored in the reconciler stash.