### PR TITLE
Track colliding child resources that are not owned

### DIFF
--- a/reconcilers/child_test.go
+++ b/reconcilers/child_test.go
@@ -413,6 +413,12 @@ func TestChildReconciler(t *testing.T) {
 					d.AddField("foo", "bar")
 				}).
 				DieReleasePtr(),
+			APIGivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}),
+			},
 			WithReactors: []rtesting.ReactionFunc{
 				rtesting.InduceFailure("create", "ConfigMap", rtesting.InduceFailureOpts{
 					Error: apierrs.NewAlreadyExists(schema.GroupResource{}, testName),
@@ -436,6 +442,9 @@ func TestChildReconciler(t *testing.T) {
 				DieReleasePtr(),
 			ExpectCreates: []client.Object{
 				configMapCreate,
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(configMapGiven, resource, scheme),
 			},
 		},
 		"child name collision, stale informer cache": {
@@ -908,6 +917,12 @@ func TestChildReconciler_Unstructured(t *testing.T) {
 					d.AddField("foo", "bar")
 				}).
 				DieReleaseUnstructured(),
+			APIGivenObjects: []client.Object{
+				configMapGiven.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.OwnerReferences()
+					}).DieReleaseUnstructured(),
+			},
 			WithReactors: []rtesting.ReactionFunc{
 				rtesting.InduceFailure("create", "ConfigMap", rtesting.InduceFailureOpts{
 					Error: apierrs.NewAlreadyExists(schema.GroupResource{}, testName),
@@ -931,6 +946,9 @@ func TestChildReconciler_Unstructured(t *testing.T) {
 				DieReleaseUnstructured(),
 			ExpectCreates: []client.Object{
 				configMapCreate.DieReleaseUnstructured(),
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(configMapGiven, resource, scheme),
 			},
 		},
 		"child name collision, stale informer cache": {


### PR DESCRIPTION
When creating a child resource with a fixed name, it's possible there already exists a resource with the same name that blocks the creation of the new resource. If this resource isn't owned by our resource (and owner relationships are utilized) that creates a blind spot where changes to that resource will not trigger a new reconcile.

We now track resources in this very specific case. When the target child resource is deleted the parent resource will now be reconciled.