### PR TITLE
Allow rtesting to use custom diff func

### DIFF
--- a/testing/config.go
+++ b/testing/config.go
@@ -59,8 +59,8 @@ type ExpectConfig struct {
 	// Interacting with a status sub-resource for a type not enumerated as having a status
 	// sub-resource will return a not found error.
 	StatusSubResourceTypes []client.Object
-	// Diff method to use to compare expected and actual values
-	Diff func(expected, actual any, reason DiffReason) string
+	// Differ methods to use to compare expected and actual values
+	Differ Differ
 
 	// GivenObjects build the kubernetes objects which are present at the onset of reconciliation
 	GivenObjects []client.Object
@@ -128,8 +128,8 @@ func (c *ExpectConfig) init() {
 		}
 		c.tracker = createTracker(c.GivenTracks, c.Scheme)
 		c.observedErrors = []string{}
-		if c.Diff == nil {
-			c.Diff = DefaultDiff
+		if c.Differ == nil {
+			c.Differ = DefaultDiffer
 		}
 	})
 }
@@ -210,7 +210,7 @@ func (c *ExpectConfig) AssertClientCreateExpectations(t *testing.T) {
 	}
 	c.init()
 
-	c.compareActions(t, "Create", c.ExpectCreates, c.client.CreateActions, DiffReasonResourceCreate)
+	c.compareActions(t, "Create", c.ExpectCreates, c.client.CreateActions, c.Differ.ResourceCreate)
 }
 
 // AssertClientUpdateExpectations asserts observed reconciler client update behavior matches the expected client update behavior
@@ -220,7 +220,7 @@ func (c *ExpectConfig) AssertClientUpdateExpectations(t *testing.T) {
 	}
 	c.init()
 
-	c.compareActions(t, "Update", c.ExpectUpdates, c.client.UpdateActions, DiffReasonResourceUpdate)
+	c.compareActions(t, "Update", c.ExpectUpdates, c.client.UpdateActions, c.Differ.ResourceUpdate)
 }
 
 // AssertClientPatchExpectations asserts observed reconciler client patch behavior matches the expected client patch behavior
@@ -237,7 +237,7 @@ func (c *ExpectConfig) AssertClientPatchExpectations(t *testing.T) {
 		}
 		actual := NewPatchRef(c.client.PatchActions[i])
 
-		if diff := c.Diff(exp, actual, DiffReasonRaw); diff != "" {
+		if diff := c.Differ.Raw(exp, actual); diff != "" {
 			c.errorf(t, "ExpectPatches[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -262,7 +262,7 @@ func (c *ExpectConfig) AssertClientDeleteExpectations(t *testing.T) {
 		}
 		actual := NewDeleteRef(c.client.DeleteActions[i])
 
-		if diff := c.Diff(exp, actual, DiffReasonRaw); diff != "" {
+		if diff := c.Differ.Raw(exp, actual); diff != "" {
 			c.errorf(t, "ExpectDeletes[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -287,7 +287,7 @@ func (c *ExpectConfig) AssertClientDeleteCollectionExpectations(t *testing.T) {
 		}
 		actual := NewDeleteCollectionRef(c.client.DeleteCollectionActions[i])
 
-		if diff := c.Diff(exp, actual, DiffReasonDeleteCollectionRef); diff != "" {
+		if diff := c.Differ.DeleteCollectionRef(exp, actual); diff != "" {
 			c.errorf(t, "ExpectDeleteCollections[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -305,7 +305,7 @@ func (c *ExpectConfig) AssertClientStatusUpdateExpectations(t *testing.T) {
 	}
 	c.init()
 
-	c.compareActions(t, "StatusUpdate", c.ExpectStatusUpdates, c.client.StatusUpdateActions, DiffReasonResourceStatusUpdate)
+	c.compareActions(t, "StatusUpdate", c.ExpectStatusUpdates, c.client.StatusUpdateActions, c.Differ.ResourceStatusUpdate)
 }
 
 // AssertClientStatusPatchExpectations asserts observed reconciler client status patch behavior matches the expected client status patch behavior
@@ -322,7 +322,7 @@ func (c *ExpectConfig) AssertClientStatusPatchExpectations(t *testing.T) {
 		}
 		actual := NewPatchRef(c.client.StatusPatchActions[i])
 
-		if diff := c.Diff(exp, actual, DiffReasonRaw); diff != "" {
+		if diff := c.Differ.Raw(exp, actual); diff != "" {
 			c.errorf(t, "ExpectStatusPatches[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -347,7 +347,7 @@ func (c *ExpectConfig) AssertRecorderExpectations(t *testing.T) {
 			continue
 		}
 
-		if diff := c.Diff(exp, actualEvents[i], DiffReasonRaw); diff != "" {
+		if diff := c.Differ.Raw(exp, actualEvents[i]); diff != "" {
 			c.errorf(t, "ExpectEvents[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -374,7 +374,7 @@ func (c *ExpectConfig) AssertTrackerExpectations(t *testing.T) {
 			continue
 		}
 
-		if diff := c.Diff(exp, actualTracks[i], DiffReasonTrackRequest); diff != "" {
+		if diff := c.Differ.TrackRequest(exp, actualTracks[i]); diff != "" {
 			c.errorf(t, "ExpectTracks[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -385,7 +385,7 @@ func (c *ExpectConfig) AssertTrackerExpectations(t *testing.T) {
 	}
 }
 
-func (c *ExpectConfig) compareActions(t *testing.T, actionName string, expectedActionFactories []client.Object, actualActions []objectAction, diffReason DiffReason) {
+func (c *ExpectConfig) compareActions(t *testing.T, actionName string, expectedActionFactories []client.Object, actualActions []objectAction, differ func(client.Object, client.Object) string) {
 	if t != nil {
 		t.Helper()
 	}
@@ -398,7 +398,7 @@ func (c *ExpectConfig) compareActions(t *testing.T, actionName string, expectedA
 		}
 		actual := actualActions[i].GetObject()
 
-		if diff := c.Diff(exp.DeepCopyObject(), actual, diffReason); diff != "" {
+		if diff := differ(exp.DeepCopyObject().(client.Object), actual.(client.Object)); diff != "" {
 			c.errorf(t, "Expect%ss[%d] differs%s (%s, %s):\n%s", actionName, i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}

--- a/testing/config.go
+++ b/testing/config.go
@@ -237,7 +237,7 @@ func (c *ExpectConfig) AssertClientPatchExpectations(t *testing.T) {
 		}
 		actual := NewPatchRef(c.client.PatchActions[i])
 
-		if diff := c.Differ.Raw(exp, actual); diff != "" {
+		if diff := c.Differ.PatchRef(exp, actual); diff != "" {
 			c.errorf(t, "ExpectPatches[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -262,7 +262,7 @@ func (c *ExpectConfig) AssertClientDeleteExpectations(t *testing.T) {
 		}
 		actual := NewDeleteRef(c.client.DeleteActions[i])
 
-		if diff := c.Differ.Raw(exp, actual); diff != "" {
+		if diff := c.Differ.DeleteRef(exp, actual); diff != "" {
 			c.errorf(t, "ExpectDeletes[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -322,7 +322,7 @@ func (c *ExpectConfig) AssertClientStatusPatchExpectations(t *testing.T) {
 		}
 		actual := NewPatchRef(c.client.StatusPatchActions[i])
 
-		if diff := c.Differ.Raw(exp, actual); diff != "" {
+		if diff := c.Differ.PatchRef(exp, actual); diff != "" {
 			c.errorf(t, "ExpectStatusPatches[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -347,7 +347,7 @@ func (c *ExpectConfig) AssertRecorderExpectations(t *testing.T) {
 			continue
 		}
 
-		if diff := c.Differ.Raw(exp, actualEvents[i]); diff != "" {
+		if diff := c.Differ.Event(exp, actualEvents[i]); diff != "" {
 			c.errorf(t, "ExpectEvents[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}

--- a/testing/config.go
+++ b/testing/config.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,6 +59,9 @@ type ExpectConfig struct {
 	// Interacting with a status sub-resource for a type not enumerated as having a status
 	// sub-resource will return a not found error.
 	StatusSubResourceTypes []client.Object
+	// Diff method to use to compare expected and actual values
+	Diff func(expected, actual any, reason DiffReason) string
+
 	// GivenObjects build the kubernetes objects which are present at the onset of reconciliation
 	GivenObjects []client.Object
 	// APIGivenObjects contains objects that are only available via an API reader instead of the normal cache
@@ -126,6 +128,9 @@ func (c *ExpectConfig) init() {
 		}
 		c.tracker = createTracker(c.GivenTracks, c.Scheme)
 		c.observedErrors = []string{}
+		if c.Diff == nil {
+			c.Diff = DefaultDiff
+		}
 	})
 }
 
@@ -205,7 +210,7 @@ func (c *ExpectConfig) AssertClientCreateExpectations(t *testing.T) {
 	}
 	c.init()
 
-	c.compareActions(t, "Create", c.ExpectCreates, c.client.CreateActions, reconcilers.IgnoreAllUnexported, IgnoreLastTransitionTime, IgnoreTypeMeta, IgnoreCreationTimestamp, IgnoreResourceVersion, cmpopts.EquateEmpty())
+	c.compareActions(t, "Create", c.ExpectCreates, c.client.CreateActions, DiffReasonResourceCreate)
 }
 
 // AssertClientUpdateExpectations asserts observed reconciler client update behavior matches the expected client update behavior
@@ -215,7 +220,7 @@ func (c *ExpectConfig) AssertClientUpdateExpectations(t *testing.T) {
 	}
 	c.init()
 
-	c.compareActions(t, "Update", c.ExpectUpdates, c.client.UpdateActions, reconcilers.IgnoreAllUnexported, IgnoreLastTransitionTime, IgnoreTypeMeta, IgnoreCreationTimestamp, IgnoreResourceVersion, cmpopts.EquateEmpty())
+	c.compareActions(t, "Update", c.ExpectUpdates, c.client.UpdateActions, DiffReasonResourceUpdate)
 }
 
 // AssertClientPatchExpectations asserts observed reconciler client patch behavior matches the expected client patch behavior
@@ -232,7 +237,7 @@ func (c *ExpectConfig) AssertClientPatchExpectations(t *testing.T) {
 		}
 		actual := NewPatchRef(c.client.PatchActions[i])
 
-		if diff := cmp.Diff(exp, actual); diff != "" {
+		if diff := c.Diff(exp, actual, DiffReasonRaw); diff != "" {
 			c.errorf(t, "ExpectPatches[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -257,7 +262,7 @@ func (c *ExpectConfig) AssertClientDeleteExpectations(t *testing.T) {
 		}
 		actual := NewDeleteRef(c.client.DeleteActions[i])
 
-		if diff := cmp.Diff(exp, actual); diff != "" {
+		if diff := c.Diff(exp, actual, DiffReasonRaw); diff != "" {
 			c.errorf(t, "ExpectDeletes[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -282,7 +287,7 @@ func (c *ExpectConfig) AssertClientDeleteCollectionExpectations(t *testing.T) {
 		}
 		actual := NewDeleteCollectionRef(c.client.DeleteCollectionActions[i])
 
-		if diff := cmp.Diff(exp, actual, NormalizeLabelSelector, NormalizeFieldSelector); diff != "" {
+		if diff := c.Diff(exp, actual, DiffReasonDeleteCollectionRef); diff != "" {
 			c.errorf(t, "ExpectDeleteCollections[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -300,7 +305,7 @@ func (c *ExpectConfig) AssertClientStatusUpdateExpectations(t *testing.T) {
 	}
 	c.init()
 
-	c.compareActions(t, "StatusUpdate", c.ExpectStatusUpdates, c.client.StatusUpdateActions, statusSubresourceOnly, reconcilers.IgnoreAllUnexported, IgnoreLastTransitionTime, cmpopts.EquateEmpty())
+	c.compareActions(t, "StatusUpdate", c.ExpectStatusUpdates, c.client.StatusUpdateActions, DiffReasonResourceStatusUpdate)
 }
 
 // AssertClientStatusPatchExpectations asserts observed reconciler client status patch behavior matches the expected client status patch behavior
@@ -317,7 +322,7 @@ func (c *ExpectConfig) AssertClientStatusPatchExpectations(t *testing.T) {
 		}
 		actual := NewPatchRef(c.client.StatusPatchActions[i])
 
-		if diff := cmp.Diff(exp, actual); diff != "" {
+		if diff := c.Diff(exp, actual, DiffReasonRaw); diff != "" {
 			c.errorf(t, "ExpectStatusPatches[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -342,7 +347,7 @@ func (c *ExpectConfig) AssertRecorderExpectations(t *testing.T) {
 			continue
 		}
 
-		if diff := cmp.Diff(exp, actualEvents[i]); diff != "" {
+		if diff := c.Diff(exp, actualEvents[i], DiffReasonRaw); diff != "" {
 			c.errorf(t, "ExpectEvents[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -369,7 +374,7 @@ func (c *ExpectConfig) AssertTrackerExpectations(t *testing.T) {
 			continue
 		}
 
-		if diff := cmp.Diff(exp, actualTracks[i], NormalizeLabelSelector); diff != "" {
+		if diff := c.Diff(exp, actualTracks[i], DiffReasonTrackRequest); diff != "" {
 			c.errorf(t, "ExpectTracks[%d] differs%s (%s, %s):\n%s", i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}
@@ -380,7 +385,7 @@ func (c *ExpectConfig) AssertTrackerExpectations(t *testing.T) {
 	}
 }
 
-func (c *ExpectConfig) compareActions(t *testing.T, actionName string, expectedActionFactories []client.Object, actualActions []objectAction, diffOptions ...cmp.Option) {
+func (c *ExpectConfig) compareActions(t *testing.T, actionName string, expectedActionFactories []client.Object, actualActions []objectAction, diffReason DiffReason) {
 	if t != nil {
 		t.Helper()
 	}
@@ -393,7 +398,7 @@ func (c *ExpectConfig) compareActions(t *testing.T, actionName string, expectedA
 		}
 		actual := actualActions[i].GetObject()
 
-		if diff := cmp.Diff(exp.DeepCopyObject(), actual, diffOptions...); diff != "" {
+		if diff := c.Diff(exp.DeepCopyObject(), actual, diffReason); diff != "" {
 			c.errorf(t, "Expect%ss[%d] differs%s (%s, %s):\n%s", actionName, i, c.configNameMsg(), DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}

--- a/testing/config_test.go
+++ b/testing/config_test.go
@@ -687,8 +687,8 @@ func TestExpectConfig(t *testing.T) {
 
 		"custom diff - always different": {
 			config: ExpectConfig{
-				Diff: func(expected, actual any, reason DiffReason) string {
-					return "always different"
+				Differ: &staticDiffer{
+					diff: "always different",
 				},
 				ExpectTracks: []TrackRequest{
 					NewTrackRequest(r2, r1, scheme),
@@ -743,8 +743,8 @@ func TestExpectConfig(t *testing.T) {
 		},
 		"custom diff - never different": {
 			config: ExpectConfig{
-				Diff: func(expected, actual any, reason DiffReason) string {
-					return ""
+				Differ: &staticDiffer{
+					diff: "",
 				},
 				ExpectTracks: []TrackRequest{
 					NewTrackRequest(r2, r1, scheme),

--- a/testing/diff.go
+++ b/testing/diff.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"reconciler.io/runtime/reconcilers"
+)
+
+type DiffReason float64
+
+const (
+	DiffReasonRaw DiffReason = iota
+	DiffReasonTrackRequest
+	DiffReasonDeleteCollectionRef
+	DiffReasonStashedValue
+	DiffReasonResource
+	DiffReasonWebhookResponse
+	DiffReasonResourceStatusUpdate
+	DiffReasonResourceUpdate
+	DiffReasonResourceCreate
+)
+
+func DefaultDiff[T any](expected, actual T, reason DiffReason) string {
+	opts := []cmp.Option{}
+	switch reason {
+	case DiffReasonTrackRequest:
+		opts = []cmp.Option{
+			NormalizeLabelSelector,
+		}
+	case DiffReasonDeleteCollectionRef:
+		opts = []cmp.Option{
+			NormalizeLabelSelector,
+			NormalizeFieldSelector,
+		}
+	case DiffReasonStashedValue:
+		opts = []cmp.Option{
+			reconcilers.IgnoreAllUnexported,
+			IgnoreLastTransitionTime,
+			IgnoreTypeMeta,
+			IgnoreCreationTimestamp,
+			IgnoreResourceVersion,
+			cmpopts.EquateEmpty(),
+		}
+	case DiffReasonWebhookResponse:
+		opts = []cmp.Option{
+			reconcilers.IgnoreAllUnexported,
+		}
+	case DiffReasonResource:
+		opts = []cmp.Option{
+			reconcilers.IgnoreAllUnexported,
+			IgnoreLastTransitionTime,
+			IgnoreTypeMeta,
+			cmpopts.EquateEmpty(),
+		}
+	case DiffReasonResourceStatusUpdate:
+		opts = []cmp.Option{
+			statusSubresourceOnly,
+			reconcilers.IgnoreAllUnexported,
+			IgnoreLastTransitionTime,
+			cmpopts.EquateEmpty(),
+		}
+	case DiffReasonResourceUpdate:
+		opts = []cmp.Option{
+			reconcilers.IgnoreAllUnexported,
+			IgnoreLastTransitionTime,
+			IgnoreTypeMeta,
+			IgnoreCreationTimestamp,
+			IgnoreResourceVersion,
+			cmpopts.EquateEmpty(),
+		}
+	case DiffReasonResourceCreate:
+		opts = []cmp.Option{
+			reconcilers.IgnoreAllUnexported,
+			IgnoreLastTransitionTime,
+			IgnoreTypeMeta,
+			IgnoreCreationTimestamp,
+			IgnoreResourceVersion,
+			cmpopts.EquateEmpty(),
+		}
+	}
+	return cmp.Diff(expected, actual, opts...)
+}

--- a/testing/diff.go
+++ b/testing/diff.go
@@ -25,8 +25,11 @@ import (
 )
 
 type Differ interface {
-	Raw(expected, actual any) string
+	Result(expected, actual reconcilers.Result) string
 	TrackRequest(expected, actual TrackRequest) string
+	Event(expected, actual Event) string
+	PatchRef(expected, actual PatchRef) string
+	DeleteRef(expected, actual DeleteRef) string
 	DeleteCollectionRef(expected, actual DeleteCollectionRef) string
 	StashedValue(expected, actual any, key reconcilers.StashKey) string
 	Resource(expected, actual client.Object) string
@@ -42,12 +45,24 @@ var DefaultDiffer Differ = &differ{}
 
 type differ struct{}
 
-func (*differ) Raw(expected, actual any) string {
+func (*differ) Result(expected, actual reconcilers.Result) string {
 	return cmp.Diff(expected, actual)
 }
 
 func (*differ) TrackRequest(expected, actual TrackRequest) string {
 	return cmp.Diff(expected, actual, NormalizeLabelSelector)
+}
+
+func (*differ) Event(expected, actual Event) string {
+	return cmp.Diff(expected, actual)
+}
+
+func (*differ) PatchRef(expected, actual PatchRef) string {
+	return cmp.Diff(expected, actual)
+}
+
+func (*differ) DeleteRef(expected, actual DeleteRef) string {
+	return cmp.Diff(expected, actual)
 }
 
 func (*differ) DeleteCollectionRef(expected, actual DeleteCollectionRef) string {

--- a/testing/diff.go
+++ b/testing/diff.go
@@ -20,79 +20,81 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"reconciler.io/runtime/reconcilers"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-type DiffReason float64
+type Differ interface {
+	Raw(expected, actual any) string
+	TrackRequest(expected, actual TrackRequest) string
+	DeleteCollectionRef(expected, actual DeleteCollectionRef) string
+	StashedValue(expected, actual any, key reconcilers.StashKey) string
+	Resource(expected, actual client.Object) string
+	ResourceStatusUpdate(expected, actual client.Object) string
+	ResourceUpdate(expected, actual client.Object) string
+	ResourceCreate(expected, actual client.Object) string
+	WebhookResponse(expected, actual admission.Response) string
+}
 
-const (
-	DiffReasonRaw DiffReason = iota
-	DiffReasonTrackRequest
-	DiffReasonDeleteCollectionRef
-	DiffReasonStashedValue
-	DiffReasonResource
-	DiffReasonWebhookResponse
-	DiffReasonResourceStatusUpdate
-	DiffReasonResourceUpdate
-	DiffReasonResourceCreate
-)
+// DefaultDiffer is a basic implementation of the Differ interface that is used by default unless
+// overridden for a specific test case or globally.
+var DefaultDiffer Differ = &differ{}
 
-func DefaultDiff[T any](expected, actual T, reason DiffReason) string {
-	opts := []cmp.Option{}
-	switch reason {
-	case DiffReasonTrackRequest:
-		opts = []cmp.Option{
-			NormalizeLabelSelector,
-		}
-	case DiffReasonDeleteCollectionRef:
-		opts = []cmp.Option{
-			NormalizeLabelSelector,
-			NormalizeFieldSelector,
-		}
-	case DiffReasonStashedValue:
-		opts = []cmp.Option{
-			reconcilers.IgnoreAllUnexported,
-			IgnoreLastTransitionTime,
-			IgnoreTypeMeta,
-			IgnoreCreationTimestamp,
-			IgnoreResourceVersion,
-			cmpopts.EquateEmpty(),
-		}
-	case DiffReasonWebhookResponse:
-		opts = []cmp.Option{
-			reconcilers.IgnoreAllUnexported,
-		}
-	case DiffReasonResource:
-		opts = []cmp.Option{
-			reconcilers.IgnoreAllUnexported,
-			IgnoreLastTransitionTime,
-			IgnoreTypeMeta,
-			cmpopts.EquateEmpty(),
-		}
-	case DiffReasonResourceStatusUpdate:
-		opts = []cmp.Option{
-			statusSubresourceOnly,
-			reconcilers.IgnoreAllUnexported,
-			IgnoreLastTransitionTime,
-			cmpopts.EquateEmpty(),
-		}
-	case DiffReasonResourceUpdate:
-		opts = []cmp.Option{
-			reconcilers.IgnoreAllUnexported,
-			IgnoreLastTransitionTime,
-			IgnoreTypeMeta,
-			IgnoreCreationTimestamp,
-			IgnoreResourceVersion,
-			cmpopts.EquateEmpty(),
-		}
-	case DiffReasonResourceCreate:
-		opts = []cmp.Option{
-			reconcilers.IgnoreAllUnexported,
-			IgnoreLastTransitionTime,
-			IgnoreTypeMeta,
-			IgnoreCreationTimestamp,
-			IgnoreResourceVersion,
-			cmpopts.EquateEmpty(),
-		}
-	}
-	return cmp.Diff(expected, actual, opts...)
+type differ struct{}
+
+func (*differ) Raw(expected, actual any) string {
+	return cmp.Diff(expected, actual)
+}
+
+func (*differ) TrackRequest(expected, actual TrackRequest) string {
+	return cmp.Diff(expected, actual, NormalizeLabelSelector)
+}
+
+func (*differ) DeleteCollectionRef(expected, actual DeleteCollectionRef) string {
+	return cmp.Diff(expected, actual, NormalizeLabelSelector, NormalizeFieldSelector)
+}
+
+func (*differ) StashedValue(expected, actual any, key reconcilers.StashKey) string {
+	return cmp.Diff(expected, actual, reconcilers.IgnoreAllUnexported,
+		IgnoreLastTransitionTime,
+		IgnoreTypeMeta,
+		IgnoreCreationTimestamp,
+		IgnoreResourceVersion,
+		cmpopts.EquateEmpty())
+}
+
+func (*differ) Resource(expected, actual client.Object) string {
+	return cmp.Diff(expected, actual, reconcilers.IgnoreAllUnexported,
+		IgnoreLastTransitionTime,
+		IgnoreTypeMeta,
+		cmpopts.EquateEmpty())
+}
+
+func (*differ) ResourceStatusUpdate(expected, actual client.Object) string {
+	return cmp.Diff(expected, actual, statusSubresourceOnly,
+		reconcilers.IgnoreAllUnexported,
+		IgnoreLastTransitionTime,
+		cmpopts.EquateEmpty())
+}
+
+func (*differ) ResourceUpdate(expected, actual client.Object) string {
+	return cmp.Diff(expected, actual, reconcilers.IgnoreAllUnexported,
+		IgnoreLastTransitionTime,
+		IgnoreTypeMeta,
+		IgnoreCreationTimestamp,
+		IgnoreResourceVersion,
+		cmpopts.EquateEmpty())
+}
+
+func (*differ) ResourceCreate(expected, actual client.Object) string {
+	return cmp.Diff(expected, actual, reconcilers.IgnoreAllUnexported,
+		IgnoreLastTransitionTime,
+		IgnoreTypeMeta,
+		IgnoreCreationTimestamp,
+		IgnoreResourceVersion,
+		cmpopts.EquateEmpty())
+}
+
+func (*differ) WebhookResponse(expected, actual admission.Response) string {
+	return cmp.Diff(expected, actual, reconcilers.IgnoreAllUnexported)
 }

--- a/testing/diff_test.go
+++ b/testing/diff_test.go
@@ -26,11 +26,23 @@ type staticDiffer struct {
 	diff string
 }
 
-func (d *staticDiffer) Raw(expected, actual any) string {
+func (d *staticDiffer) Result(expected, actual reconcilers.Result) string {
 	return d.diff
 }
 
 func (d *staticDiffer) TrackRequest(expected, actual TrackRequest) string {
+	return d.diff
+}
+
+func (d *staticDiffer) Event(expected, actual Event) string {
+	return d.diff
+}
+
+func (d *staticDiffer) PatchRef(expected, actual PatchRef) string {
+	return d.diff
+}
+
+func (d *staticDiffer) DeleteRef(expected, actual DeleteRef) string {
 	return d.diff
 }
 

--- a/testing/diff_test.go
+++ b/testing/diff_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"reconciler.io/runtime/reconcilers"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type staticDiffer struct {
+	diff string
+}
+
+func (d *staticDiffer) Raw(expected, actual any) string {
+	return d.diff
+}
+
+func (d *staticDiffer) TrackRequest(expected, actual TrackRequest) string {
+	return d.diff
+}
+
+func (d *staticDiffer) DeleteCollectionRef(expected, actual DeleteCollectionRef) string {
+	return d.diff
+}
+
+func (d *staticDiffer) StashedValue(expected, actual any, key reconcilers.StashKey) string {
+	return d.diff
+}
+
+func (d *staticDiffer) Resource(expected, actual client.Object) string {
+	return d.diff
+}
+
+func (d *staticDiffer) ResourceStatusUpdate(expected, actual client.Object) string {
+	return d.diff
+}
+
+func (d *staticDiffer) ResourceUpdate(expected, actual client.Object) string {
+	return d.diff
+}
+
+func (d *staticDiffer) ResourceCreate(expected, actual client.Object) string {
+	return d.diff
+}
+
+func (d *staticDiffer) WebhookResponse(expected, actual admission.Response) string {
+	return d.diff
+}

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -231,7 +231,7 @@ func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory 
 	}
 	if err == nil {
 		// result is only significant if there wasn't an error
-		if diff := tc.Differ.Raw(normalizeResult(tc.ExpectedResult), normalizeResult(result)); diff != "" {
+		if diff := tc.Differ.Result(normalizeResult(tc.ExpectedResult), normalizeResult(result)); diff != "" {
 			t.Errorf("ExpectedResult differs (%s, %s): %s", DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -120,8 +120,8 @@ type ReconcilerTestCase struct {
 	// Now is the time the test should run as, defaults to the current time. This value can be used
 	// by reconcilers via the reconcilers.RetireveNow(ctx) method.
 	Now time.Time
-	// Diff method to use to compare expected and actual values. An empty string is returned for equivalent items.
-	Diff func(expected, actual any, reason DiffReason) string
+	// Differ methods to use to compare expected and actual values. An empty string is returned for equivalent items.
+	Differ Differ
 }
 
 // VerifyFunc is a verification function for a reconciler's result
@@ -170,8 +170,8 @@ func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory 
 	if tc.Metadata == nil {
 		tc.Metadata = map[string]interface{}{}
 	}
-	if tc.Diff == nil {
-		tc.Diff = DefaultDiff
+	if tc.Differ == nil {
+		tc.Differ = DefaultDiffer
 	}
 
 	if tc.Prepare != nil {
@@ -192,7 +192,7 @@ func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory 
 		Name:                    "default",
 		Scheme:                  scheme,
 		StatusSubResourceTypes:  tc.StatusSubResourceTypes,
-		Diff:                    tc.Diff,
+		Differ:                  tc.Differ,
 		GivenObjects:            tc.GivenObjects,
 		APIGivenObjects:         tc.APIGivenObjects,
 		WithClientBuilder:       tc.WithClientBuilder,
@@ -231,7 +231,7 @@ func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory 
 	}
 	if err == nil {
 		// result is only significant if there wasn't an error
-		if diff := tc.Diff(normalizeResult(tc.ExpectedResult), normalizeResult(result), DiffReasonRaw); diff != "" {
+		if diff := tc.Differ.Raw(normalizeResult(tc.ExpectedResult), normalizeResult(result)); diff != "" {
 			t.Errorf("ExpectedResult differs (%s, %s): %s", DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -284,7 +284,7 @@ func (tc *SubReconcilerTestCase[T]) Run(t *testing.T, scheme *runtime.Scheme, fa
 	}
 	if err == nil {
 		// result is only significant if there wasn't an error
-		if diff := tc.Differ.Raw(normalizeResult(tc.ExpectedResult), normalizeResult(result)); diff != "" {
+		if diff := tc.Differ.Result(normalizeResult(tc.ExpectedResult), normalizeResult(result)); diff != "" {
 			t.Errorf("ExpectedResult differs (%s, %s): %s", DiffRemovedColor.Sprint("-expected"), DiffAddedColor.Sprint("+actual"), ColorizeDiff(diff))
 		}
 	}


### PR DESCRIPTION
Test cases can now specify a custom diff function which can be used to either use custom cmp options, or replace cmp with some other differ.

The existing set of cmp options are matched using the DiffReason. Custom funcs should assume additional DiffReasons will be defined in the future. The DefaultDiff func is used if a custom Diff is not defined. Custom funcs may delegate to the default for DiffReasons they choose not to modify.

Refs #589 