### PR TITLE
Quiet errors are always actually quiet

### DIFF
--- a/reconcilers/reconcilers_test.go
+++ b/reconcilers/reconcilers_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 the original author or authors.
+Copyright 2025 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/reconcilers/reconcilers_test.go
+++ b/reconcilers/reconcilers_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers_test
+
+import (
+	"errors"
+	"testing"
+
+	"reconciler.io/runtime/reconcilers"
+)
+
+func TestErrHaltSubReconcilers(t *testing.T) {
+	if !errors.Is(reconcilers.ErrHaltSubReconcilers, reconcilers.ErrQuiet) {
+		t.Errorf("ErrHaltSubReconcilers should be ErrQuiet")
+	}
+}

--- a/reconcilers/resource_test.go
+++ b/reconcilers/resource_test.go
@@ -640,6 +640,7 @@ func TestResourceReconciler_Duck(t *testing.T) {
 					Patch:       []byte(`{"spec":{"fields":{"Defaulter":"ran"}},"status":{"fields":{"want":"this to run"}}}`),
 				},
 			},
+			ExpectedResult: reconcilers.Result{Requeue: true},
 		},
 		"sub reconciler halted with result": {
 			Request: testRequest,
@@ -657,7 +658,7 @@ func TestResourceReconciler_Duck(t *testing.T) {
 								resource.Status.Fields = map[string]string{
 									"want": "this to run",
 								}
-								return reconcilers.Result{Requeue: true}, reconcilers.ErrHaltSubReconcilers
+								return reconcilers.Result{RequeueAfter: 10}, reconcilers.ErrHaltSubReconcilers
 							},
 						},
 						&reconcilers.SyncReconciler[*resources.TestDuck]{
@@ -1161,6 +1162,7 @@ func TestResourceReconciler(t *testing.T) {
 					d.AddField("want", "this to run")
 				}),
 			},
+			ExpectedResult: reconcile.Result{Requeue: true},
 		},
 		"sub reconciler halted with result": {
 			Request: testRequest,
@@ -1178,7 +1180,7 @@ func TestResourceReconciler(t *testing.T) {
 								resource.Status.Fields = map[string]string{
 									"want": "this to run",
 								}
-								return reconcilers.Result{Requeue: true}, reconcilers.ErrHaltSubReconcilers
+								return reconcilers.Result{RequeueAfter: 10}, reconcilers.ErrHaltSubReconcilers
 							},
 						},
 						&reconcilers.SyncReconciler[*resources.TestResource]{


### PR DESCRIPTION
controller-runtime will always log an error returned to it from a reconciler. In order to avoid the quieted errors from appearing in the logs, we need to return a nil error. To get the same effect of an error without the logging, we also request a requeue. The requeue is handled the same as if the request erred in terms of the workqueue backoffs.