### PR TITLE
Allow ResourceReconciler to skip processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ The resource reconciler is responsible for:
 The implementor is responsible for:
 - defining the set of sub reconcilers
 
+The processing of a specific request or resource may be skipped by implementing and returning `true` from either [`SkipRequest`](https://pkg.go.dev/reconciler.io/runtime/reconcilers#ResourceReconciler.SkipRequest), or [`SkipResource`](https://pkg.go.dev/reconciler.io/runtime/reconcilers#ResourceReconciler.SkipResource) respectively.
+
 **Example:**
 
 Resource reconcilers tend to be quite simple, as they delegate their work to sub reconcilers. We'll use an example from projectriff of the Function resource, which uses Kpack to build images from a git repo. In this case the `FunctionTargetImageReconciler` resolves the target image for the function, and `FunctionChildImageReconciler` creates a child Kpack Image resource based on the resolve value. 

--- a/reconcilers/resource.go
+++ b/reconcilers/resource.go
@@ -108,7 +108,7 @@ type ResourceReconciler[Type client.Object] struct {
 	// +optional
 	SkipRequest func(ctx context.Context, req Request) bool
 
-	// SkipResource short cuts the reconciler for the specific resource. The Reconciler is not be
+	// SkipResource shortcuts the reconciler for the specific resource. The Reconciler is not
 	// called and the status is not updated.
 	//
 	// BeforeReconcile and AfterReconcile are called, and the resource's defaults are applied.

--- a/reconcilers/resource.go
+++ b/reconcilers/resource.go
@@ -102,16 +102,17 @@ type ResourceReconciler[Type client.Object] struct {
 	// +optional
 	AfterReconcile func(ctx context.Context, req Request, res Result, err error) (Result, error)
 
-	// SkipResource shortcuts the reconciler for the specific request. The context and logger are
-	// initialized, but no work is preformed and the request is removed from the workqueue.
+	// SkipResource shortcuts the reconciler for the specific request. While the context and logger
+	// are initialized, no work is preformed. The request is removed from the workqueue.
 	//
 	// +optional
 	SkipRequest func(ctx context.Context, req Request) bool
 
 	// SkipResource shortcuts the reconciler for the specific resource. The Reconciler is not
-	// called and the status is not updated.
+	// called and the resource's status is not updated.
 	//
-	// BeforeReconcile and AfterReconcile are called, and the resource's defaults are applied.
+	// BeforeReconcile and AfterReconcile are called, and the resource's defaults are applied
+	// before calling this method.
 	//
 	// +optional
 	SkipResource func(ctx context.Context, resource Type) bool


### PR DESCRIPTION
There are two hooks that will suppress the reconciliation:
- SkipRequest: no work is preformed
- SkipResource: the resource is loaded and defaulted

Favor SkipRequest if a decision can be made based solely on the Namespace or Name. Use SkipResource if context of the resource is needed.

The context is initialized before either call, allowing access to a client or logger.