### PR TITLE
Always reconciler

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Within an existing Kubebuilder or controller-runtime project, reconcilers.io may
 	- [Higher-order Reconcilers](#higher-order-reconcilers)
 		- [CastResource](#castresource)
 		- [Sequence](#sequence)
+		- [Always](#always)
 		- [Advice](#advice)
 		- [IfThen](#ifthen)
 		- [While](#while)
@@ -462,6 +463,12 @@ func FunctionReconciler(c reconcilers.Config) *reconcilers.ResourceReconciler[*b
 }
 ```
 [full source](https://github.com/projectriff/system/blob/4c3b75327bf99cc37b57ba14df4c65d21dc79d28/pkg/controllers/build/function_reconciler.go#L39-L51)
+
+#### Always
+
+An [`Always`](https://pkg.go.dev/reconciler.io/runtime/reconcilers#Always) composes multiple `SubReconciler`s as a single `SubReconciler`. Each sub reconciler is called in turn, aggregating the result and error of each sub reconciler. `Always` only differs from [`Sequence`](#sequence) in how errors are handled. Unlike `Sequence`, an error will not interrupt the flow.
+
+The returned error joins all returned errors. It will only match `ErrQuiet` if all errors also match `ErrQuiet`.
 
 #### Advice
 

--- a/reconcilers/always.go
+++ b/reconcilers/always.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"reconciler.io/runtime/validation"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ SubReconciler[client.Object] = (Always[client.Object])(nil)
+
+// Always is a collection of SubReconcilers called in order. Each reconciler is called regardless
+// of previous errors. The resulting errors are joined. The resulting joined error will only match
+// ErrQuiet if all contributing errors match ErrQuiet.
+type Always[Type client.Object] []SubReconciler[Type]
+
+func (r Always[T]) SetupWithManager(ctx context.Context, mgr ctrl.Manager, bldr *builder.Builder) error {
+	for i, reconciler := range r {
+		log := logr.FromContextOrDiscard(ctx).
+			WithName(fmt.Sprintf("%d", i))
+		ctx = logr.NewContext(ctx, log)
+
+		err := reconciler.SetupWithManager(ctx, mgr, bldr)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r Always[T]) Reconcile(ctx context.Context, resource T) (Result, error) {
+	aggregateResult := Result{}
+	aggregateErrors := []error{}
+	aggregateNonQuietErrors := []error{}
+	for i, reconciler := range r {
+		log := logr.FromContextOrDiscard(ctx).
+			WithName(fmt.Sprintf("%d", i))
+		ctx := logr.NewContext(ctx, log)
+
+		result, err := reconciler.Reconcile(ctx, resource)
+		aggregateResult = AggregateResults(result, aggregateResult)
+		if err != nil {
+			aggregateErrors = append(aggregateErrors, err)
+			if !errors.Is(err, ErrQuiet) {
+				aggregateNonQuietErrors = append(aggregateNonQuietErrors, err)
+			}
+		}
+	}
+	// only return an ErrQuiet if all errors are quiet
+	if err := errors.Join(aggregateNonQuietErrors...); err != nil {
+		return aggregateResult, err
+	}
+	return aggregateResult, errors.Join(aggregateErrors...)
+}
+
+func (r *Always[T]) Validate(ctx context.Context) error {
+	// validate Always
+	if validation.IsRecursive(ctx) {
+		for i, reconciler := range *r {
+			if v, ok := reconciler.(validation.Validator); ok {
+				if err := v.Validate(ctx); err != nil {
+					return fmt.Errorf("Always must have a valid Always[%d]: %w", i, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Always is a collection of SubReconcilers called in order. Each reconciler is called regardless of previous errors. The resulting errors are joined. The resulting joined error will only match ErrQuiet if all contributing errors match ErrQuiet.

Always is identical to Sequence, except for error handling.