### PR TITLE
Allow ChildReconciler to return user defined errors

### DIFF
--- a/reconcilers/child_test.go
+++ b/reconcilers/child_test.go
@@ -1187,6 +1187,19 @@ func TestChildReconciler_Validate(t *testing.T) {
 			},
 		},
 		{
+			name:   "valid, ReflectChildStatusOnParentWithError",
+			parent: &corev1.ConfigMap{},
+			reconciler: &reconcilers.ChildReconciler[*corev1.ConfigMap, *corev1.Pod, *corev1.PodList]{
+				ChildType:     &corev1.Pod{},
+				ChildListType: &corev1.PodList{},
+				DesiredChild:  func(ctx context.Context, parent *corev1.ConfigMap) (*corev1.Pod, error) { return nil, nil },
+				ChildObjectManager: &reconcilers.UpdatingObjectManager[*corev1.Pod]{
+					MergeBeforeUpdate: func(current, desired *corev1.Pod) {},
+				},
+				ReflectChildStatusOnParentWithError: func(ctx context.Context, parent *corev1.ConfigMap, child *corev1.Pod, err error) error { return nil },
+			},
+		},
+		{
 			name:   "ChildType missing",
 			parent: &corev1.ConfigMap{},
 			reconciler: &reconcilers.ChildReconciler[*corev1.ConfigMap, *corev1.Pod, *corev1.PodList]{
@@ -1242,7 +1255,7 @@ func TestChildReconciler_Validate(t *testing.T) {
 				},
 				// ReflectChildStatusOnParent: func(parent *corev1.ConfigMap, child *corev1.Pod, err error) {},
 			},
-			shouldErr: `ChildReconciler "ReflectChildStatusOnParent missing" must implement ReflectChildStatusOnParent`,
+			shouldErr: `ChildReconciler "ReflectChildStatusOnParent missing" must implement ReflectChildStatusOnParent or ReflectChildStatusOnParentWithError`,
 		},
 		{
 			name:   "ListOptions",

--- a/reconcilers/childset_test.go
+++ b/reconcilers/childset_test.go
@@ -682,6 +682,22 @@ func TestChildSetReconciler_Validate(t *testing.T) {
 			},
 		},
 		{
+			name:   "valid, ReflectChildrenStatusOnParentWithError",
+			parent: &corev1.ConfigMap{},
+			reconciler: &reconcilers.ChildSetReconciler[*corev1.ConfigMap, *corev1.Pod, *corev1.PodList]{
+				ChildType:       &corev1.Pod{},
+				ChildListType:   &corev1.PodList{},
+				DesiredChildren: func(ctx context.Context, parent *corev1.ConfigMap) ([]*corev1.Pod, error) { return nil, nil },
+				ChildObjectManager: &reconcilers.UpdatingObjectManager[*corev1.Pod]{
+					MergeBeforeUpdate: func(current, desired *corev1.Pod) {},
+				},
+				ReflectChildrenStatusOnParentWithError: func(ctx context.Context, parent *corev1.ConfigMap, result reconcilers.ChildSetResult[*corev1.Pod]) error {
+					return nil
+				},
+				IdentifyChild: func(child *corev1.Pod) string { return "" },
+			},
+		},
+		{
 			name:   "ChildType missing",
 			parent: &corev1.ConfigMap{},
 			reconciler: &reconcilers.ChildSetReconciler[*corev1.ConfigMap, *corev1.Pod, *corev1.PodList]{
@@ -741,7 +757,7 @@ func TestChildSetReconciler_Validate(t *testing.T) {
 				// ReflectChildrenStatusOnParent: func(parent *corev1.ConfigMap, child *corev1.Pod, err error) {},
 				IdentifyChild: func(child *corev1.Pod) string { return "" },
 			},
-			shouldErr: `ChildSetReconciler "ReflectChildrenStatusOnParent missing" must implement ReflectChildrenStatusOnParent`,
+			shouldErr: `ChildSetReconciler "ReflectChildrenStatusOnParent missing" must implement ReflectChildrenStatusOnParent or ReflectChildrenStatusOnParentWithError`,
 		},
 		{
 			name:   "IdentifyChild missing",


### PR DESCRIPTION
The ReflectChildStatusOnParent method has a new variant which can return error, ReflectChildStatusOnParentWithError. They are otherwise equivalent.

The new method makes returning semantically aware errors based on the child's state much easier. Most users should stick with ReflectChildStatusOnParent.

The equivalent change also exists in ChildSetReconciler.