### PR TITLE
SuppressTransientErrors sub reconciler

### DIFF
--- a/reconcilers/errors.go
+++ b/reconcilers/errors.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2025 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"reconciler.io/runtime/internal"
+	rtime "reconciler.io/runtime/time"
+	"reconciler.io/runtime/validation"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// ErrDurable is an error which the reconcile request should not be retried until the observed
+	// state has changed. Meaningful state about the error has been captured on the status
+	ErrDurable = errors.Join(ErrQuiet, ErrHaltSubReconcilers)
+)
+
+type SuppressTransientErrors[Type client.Object, ListType client.ObjectList] struct {
+	// Name used to identify this reconciler.  Defaults to `ForEach`. Ideally unique, but not
+	// required to be so.
+	//
+	// +optional
+	Name string
+
+	// ListType is the listing type for the type. For example, PodList is the list type for Pod.
+	// Required when the generic type is not a struct, or is unstructured.
+	//
+	// +optional
+	ListType ListType
+
+	// Setup performs initialization on the manager and builder this reconciler will run with. It's
+	// common to setup field indexes and watch resources.
+	//
+	// +optional
+	Setup func(ctx context.Context, mgr ctrl.Manager, bldr *builder.Builder) error
+
+	// Threshold is the number of non-ErrDurable error reconciles encountered for a specific
+	// resource generation before which status update is suppressed.
+	Threshold uint8
+
+	// Reconciler to be called for each iterable item
+	Reconciler SubReconciler[Type]
+
+	lazyInit     sync.Once
+	m            sync.Mutex
+	lastPurge    time.Time
+	errorCounter map[types.UID]transientErrorCounter
+}
+
+func (r *SuppressTransientErrors[T, LT]) SetupWithManager(ctx context.Context, mgr ctrl.Manager, bldr *builder.Builder) error {
+	r.init()
+
+	log := logr.FromContextOrDiscard(ctx).
+		WithName(r.Name)
+	ctx = logr.NewContext(ctx, log)
+
+	if err := r.Validate(ctx); err != nil {
+		return err
+	}
+	if err := r.Reconciler.SetupWithManager(ctx, mgr, bldr); err != nil {
+		return err
+	}
+	if r.Setup == nil {
+		return nil
+	}
+	return r.Setup(ctx, mgr, bldr)
+}
+
+func (r *SuppressTransientErrors[T, LT]) init() {
+	r.lazyInit.Do(func() {
+		if r.Name == "" {
+			r.Name = "SuppressTransientErrors"
+		}
+		if internal.IsNil(r.ListType) {
+			var nilLT LT
+			r.ListType = newEmpty(nilLT).(LT)
+		}
+		if r.Threshold == 0 {
+			r.Threshold = 3
+		}
+		r.errorCounter = map[types.UID]transientErrorCounter{}
+	})
+}
+
+func (r *SuppressTransientErrors[T, LT]) checkStaleCounters(ctx context.Context) {
+	now := rtime.RetrieveNow(ctx)
+	log := logr.FromContextOrDiscard(ctx)
+
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if r.lastPurge.IsZero() {
+		r.lastPurge = now
+		return
+	}
+	if r.lastPurge.Add(24 * time.Hour).After(now) {
+		return
+	}
+
+	log.Info("purging stale resource counters")
+
+	c := RetrieveConfigOrDie(ctx)
+	list := r.ListType.DeepCopyObject().(LT)
+	if err := c.List(ctx, list); err != nil {
+		log.Error(err, "purge failed to list resources")
+		return
+	}
+
+	validIds := sets.New[types.UID]()
+	for _, item := range extractItems[T](list) {
+		validIds.Insert(item.GetUID())
+	}
+
+	counterIds := sets.New[types.UID]()
+	for uid := range r.errorCounter {
+		counterIds.Insert(uid)
+	}
+
+	for _, uid := range counterIds.Difference(validIds).UnsortedList() {
+		log.V(2).Info("purging counter", "id", uid)
+		delete(r.errorCounter, uid)
+	}
+
+	r.lastPurge = now
+}
+
+func (r *SuppressTransientErrors[T, LT]) Validate(ctx context.Context) error {
+	r.init()
+
+	// validate Reconciler
+	if r.Reconciler == nil {
+		return fmt.Errorf("SuppressTransientErrors %q must implement Reconciler", r.Name)
+	}
+	if validation.IsRecursive(ctx) {
+		if v, ok := r.Reconciler.(validation.Validator); ok {
+			if err := v.Validate(ctx); err != nil {
+				return fmt.Errorf("SuppressTransientErrors %q must have a valid Reconciler: %w", r.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *SuppressTransientErrors[T, LT]) Reconcile(ctx context.Context, resource T) (Result, error) {
+	log := logr.FromContextOrDiscard(ctx).
+		WithName(r.Name)
+	ctx = logr.NewContext(ctx, log)
+
+	defer r.checkStaleCounters(ctx)
+
+	result, err := r.Reconciler.Reconcile(ctx, resource)
+
+	if err == nil || errors.Is(err, ErrDurable) {
+		delete(r.errorCounter, resource.GetUID())
+		return result, err
+	}
+
+	// concurrent map access is ok, since keys are resources specific and a given resource will never be processed concurrently
+	counter, ok := r.errorCounter[resource.GetUID()]
+	if !ok || counter.Generation != resource.GetGeneration() {
+		counter = transientErrorCounter{
+			Generation: resource.GetGeneration(),
+			Count:      0,
+		}
+	}
+
+	// check overflow before incrementing
+	if counter.Count != uint8(255) {
+		counter.Count = counter.Count + 1
+		r.errorCounter[resource.GetUID()] = counter
+	}
+
+	if counter.Count < r.Threshold {
+		// suppress status update
+		return result, errors.Join(err, ErrSkipStatusUpdate, ErrQuiet)
+	}
+
+	return result, err
+}
+
+type transientErrorCounter struct {
+	Generation int64
+	Count      uint8
+}

--- a/reconcilers/errors_test.go
+++ b/reconcilers/errors_test.go
@@ -1,0 +1,476 @@
+/*
+Copyright 2023 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	diemetav1 "reconciler.io/dies/apis/meta/v1"
+	"reconciler.io/runtime/apis"
+	"reconciler.io/runtime/internal/resources"
+	"reconciler.io/runtime/internal/resources/dies"
+	"reconciler.io/runtime/reconcilers"
+	rtesting "reconciler.io/runtime/testing"
+	"reconciler.io/runtime/validation"
+)
+
+func TestSuppressTransientErrors(t *testing.T) {
+	testNamespace := "test-namespace"
+
+	now := metav1.Now()
+
+	scheme := runtime.NewScheme()
+	_ = resources.AddToScheme(scheme)
+
+	resourceBlue := dies.TestResourceBlank.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Namespace(testNamespace)
+			d.Name("blue")
+			d.Generation(1)
+			d.UID("11111111-1111-1111-1111-111111111111")
+		}).
+		StatusDie(func(d *dies.TestResourceStatusDie) {
+			d.ConditionsDie(
+				diemetav1.ConditionBlank.Type(apis.ConditionReady).Status(metav1.ConditionUnknown).Reason("Initializing"),
+			)
+		})
+	resourceGreen := resourceBlue.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Name("green")
+			d.UID("22222222-2222-2222-2222-222222222222")
+		})
+
+	rts := rtesting.SubReconcilerTests[*resources.TestResource]{
+		"no error continues": {
+			Resource: resourceBlue.DieReleasePtr(),
+			Now:      now.Time,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+					return &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{
+						Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								return nil
+							},
+						},
+					}
+				},
+			},
+		},
+		"transient error suppressed": {
+			Resource: resourceBlue.DieReleasePtr(),
+			Now:      now.Time,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+					return &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{
+						Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								return fmt.Errorf("an error")
+							},
+						},
+					}
+				},
+			},
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+					t.Errorf("error expected to be ErrSkipStatusUpdate")
+				}
+			},
+			ShouldErr: true,
+		},
+		"transient error suppressed until threshold": {
+			Resource: resourceBlue.DieReleasePtr(),
+			Now:      now.Time,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+					return &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{
+						Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								return fmt.Errorf("an error")
+							},
+						},
+					}
+				},
+			},
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+					t.Errorf("error expected to be ErrSkipStatusUpdate")
+				}
+			},
+			ShouldErr: true,
+			AdditionalReconciles: []rtesting.SubReconcilerTestCase[*resources.TestResource]{
+				{
+					Name:     "still below threshold",
+					Resource: resourceBlue.DieReleasePtr(),
+					Now:      now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+				{
+					Name:     "at threshold",
+					Resource: resourceBlue.DieReleasePtr(),
+					Now:      now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to not be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+				{
+					Name:     "above threshold",
+					Resource: resourceBlue.DieReleasePtr(),
+					Now:      now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to not be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+			},
+		},
+		"transient error suppressed until threshold, per resource": {
+			Resource: resourceBlue.DieReleasePtr(),
+			Now:      now.Time,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+					return &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{
+						Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								return fmt.Errorf("an error")
+							},
+						},
+					}
+				},
+			},
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+					t.Errorf("error expected to be ErrSkipStatusUpdate")
+				}
+			},
+			ShouldErr: true,
+			AdditionalReconciles: []rtesting.SubReconcilerTestCase[*resources.TestResource]{
+				{
+					Name:     "start green",
+					Resource: resourceGreen.DieReleasePtr(),
+					Now:      now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+				{
+					Name:     "blue still below threshold",
+					Resource: resourceBlue.DieReleasePtr(),
+					Now:      now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+				{
+					Name:     "green still below threshold",
+					Resource: resourceGreen.DieReleasePtr(),
+					Now:      now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+				{
+					Name:     "blue at threshold",
+					Resource: resourceBlue.DieReleasePtr(),
+					Now:      now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to not be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+				{
+					Name:     "green at threshold",
+					Resource: resourceGreen.DieReleasePtr(),
+					Now:      now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to not be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+				{
+					Name:     "blue above threshold",
+					Resource: resourceBlue.DieReleasePtr(),
+					Now:      now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to not be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+				{
+					Name:     "green above threshold",
+					Resource: resourceGreen.DieReleasePtr(),
+					Now:      now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to not be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+			},
+		},
+		"updated generation resets threshold": {
+			Resource: resourceBlue.DieReleasePtr(),
+			Now:      now.Time,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+					return &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{
+						Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								return fmt.Errorf("an error")
+							},
+						},
+					}
+				},
+			},
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+					t.Errorf("error expected to be ErrSkipStatusUpdate")
+				}
+			},
+			ShouldErr: true,
+			AdditionalReconciles: []rtesting.SubReconcilerTestCase[*resources.TestResource]{
+				{
+					Name:     "still below threshold",
+					Resource: resourceBlue.DieReleasePtr(),
+					Now:      now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+				{
+					Name: "bumped generation, counter reset",
+					Resource: resourceBlue.
+						MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+							d.Generation(2)
+						}).
+						DieReleasePtr(),
+					Now: now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+				{
+					Name: "still below threshold",
+					Resource: resourceBlue.
+						MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+							d.Generation(2)
+						}).
+						DieReleasePtr(),
+					Now: now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+				{
+					Name: "bumped generation again, counter reset",
+					Resource: resourceBlue.
+						MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+							d.Generation(3)
+						}).
+						DieReleasePtr(),
+					Now: now.Time,
+					Verify: func(t *testing.T, result reconcilers.Result, err error) {
+						if !errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+							t.Errorf("error expected to be ErrSkipStatusUpdate")
+						}
+					},
+					ShouldErr: true,
+				},
+			},
+		},
+		"durable error not suppressed": {
+			Resource: resourceBlue.DieReleasePtr(),
+			Now:      now.Time,
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+					return &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{
+						Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								return reconcilers.ErrDurable
+							},
+						},
+					}
+				},
+			},
+			Verify: func(t *testing.T, result reconcilers.Result, err error) {
+				if errors.Is(err, reconcilers.ErrSkipStatusUpdate) {
+					t.Errorf("error expected to not be ErrSkipStatusUpdate")
+				}
+			},
+			ShouldErr: true,
+		},
+		"purge stale counters": {
+			Resource: resourceBlue.DieReleasePtr(),
+			Now:      now.Time.Add(-25 * time.Hour),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+					return &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{
+						Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								return reconcilers.ErrQuiet
+							},
+						},
+					}
+				},
+			},
+			ShouldErr: true,
+			AdditionalReconciles: []rtesting.SubReconcilerTestCase[*resources.TestResource]{
+				{
+					Name:      "other resource",
+					Resource:  resourceGreen.DieReleasePtr(),
+					Now:       now.Time.Add(-25 * time.Hour),
+					ShouldErr: true,
+				},
+				{
+					Name:      "purge",
+					Resource:  resourceGreen.DieReleasePtr(),
+					Now:       now.Time,
+					ShouldErr: true,
+				},
+			},
+		},
+		"purge stale counters fails": {
+			Resource: resourceBlue.DieReleasePtr(),
+			Now:      now.Time.Add(-25 * time.Hour),
+			Metadata: map[string]interface{}{
+				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+					return &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{
+						Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{
+							Sync: func(ctx context.Context, resource *resources.TestResource) error {
+								return reconcilers.ErrQuiet
+							},
+						},
+					}
+				},
+			},
+			ShouldErr: true,
+			AdditionalReconciles: []rtesting.SubReconcilerTestCase[*resources.TestResource]{
+				{
+					Name:      "other resource",
+					Resource:  resourceGreen.DieReleasePtr(),
+					Now:       now.Time.Add(-25 * time.Hour),
+					ShouldErr: true,
+				},
+				{
+					Name:     "purge",
+					Resource: resourceGreen.DieReleasePtr(),
+					Now:      now.Time,
+					WithReactors: []rtesting.ReactionFunc{
+						rtesting.InduceFailure("list", "TestResourceList"),
+					},
+					ShouldErr: true,
+				},
+			},
+		},
+	}
+
+	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase[*resources.TestResource], c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
+		return rtc.Metadata["SubReconciler"].(func(*testing.T, reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource])(t, c)
+	})
+}
+
+func TestSuppressTransientErrors_Validate(t *testing.T) {
+	tests := []struct {
+		name       string
+		parent     *resources.TestResource
+		reconciler *reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]
+		shouldErr  string
+	}{
+		{
+			name:       "empty",
+			parent:     &resources.TestResource{},
+			reconciler: &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{},
+			shouldErr:  `SuppressTransientErrors "SuppressTransientErrors" must implement Reconciler`,
+		},
+		{
+			name:   "valid",
+			parent: &resources.TestResource{},
+			reconciler: &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{
+				Reconciler: &reconcilers.Sequence[*resources.TestResource]{},
+			},
+		},
+		{
+			name:   "Reconciler missing",
+			parent: &resources.TestResource{},
+			reconciler: &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{
+				Name: "Reconciler missing",
+				// Reconciler: &reconcilers.Sequence[*resources.TestResource]{},
+			},
+			shouldErr: `SuppressTransientErrors "Reconciler missing" must implement Reconciler`,
+		},
+		{
+			name:   "Reconciler invalid",
+			parent: &resources.TestResource{},
+			reconciler: &reconcilers.SuppressTransientErrors[*resources.TestResource, *resources.TestResourceList]{
+				Name:       "Reconciler invalid",
+				Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{},
+			},
+			shouldErr: `SuppressTransientErrors "Reconciler invalid" must have a valid Reconciler: SyncReconciler "SyncReconciler" must implement Sync or SyncWithResult`,
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := reconcilers.StashResourceType(context.TODO(), c.parent)
+			ctx = validation.WithRecursive(ctx)
+			err := c.reconciler.Validate(ctx)
+			if (err != nil) != (c.shouldErr != "") || (c.shouldErr != "" && c.shouldErr != err.Error()) {
+				t.Errorf("validate() error = %q, shouldErr %q", err.Error(), c.shouldErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Avoid status flapping for errors that are only passing in nature. The SuppressTransientErrors sub reconciler will skip status updates for transient errors until the error occurs three times. An error can be marked as non-transient with ErrDurable. Durable errors are those where absent a change in observed state, the error continues to be produced.

SubReconcilerTestCase now includes AdditionalReconciles which can be used to run additional reconcile requests for the same reconciler instances. This is useful for testing state stored on the reconciler itself.