### PR TITLE
Migrate dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  reviewers:
-  - scothis
-  - mamachanko
 - package-ecosystem: gomod
   directory: "/"
   groups:
@@ -17,14 +14,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  reviewers:
-  - scothis
-  - mamachanko
 - package-ecosystem: gomod
   directory: "/hack"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  reviewers:
-  - scothis
-  - mamachanko

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @scothis @mamachanko


### PR DESCRIPTION
- **ci: create CODEOWNERS**
- **ci: remove dependabot reviewers in favour of CODEOWNERS**
