### PR TITLE
Extract stash machinery into dedicated package

### DIFF
--- a/reconcilers/aggregate.go
+++ b/reconcilers/aggregate.go
@@ -34,6 +34,7 @@ import (
 
 	"reconciler.io/runtime/duck"
 	"reconciler.io/runtime/internal"
+	"reconciler.io/runtime/stash"
 	rtime "reconciler.io/runtime/time"
 	"reconciler.io/runtime/tracker"
 	"reconciler.io/runtime/validation"
@@ -227,7 +228,7 @@ func (r *AggregateReconciler[T]) Reconcile(ctx context.Context, req Request) (Re
 		return Result{}, nil
 	}
 
-	ctx = WithStash(ctx)
+	ctx = stash.WithContext(ctx)
 
 	c := r.Config
 

--- a/reconcilers/aggregate_test.go
+++ b/reconcilers/aggregate_test.go
@@ -34,6 +34,7 @@ import (
 	diemetav1 "reconciler.io/dies/apis/meta/v1"
 	"reconciler.io/runtime/internal/resources"
 	"reconciler.io/runtime/reconcilers"
+	"reconciler.io/runtime/stash"
 	rtesting "reconciler.io/runtime/testing"
 	rtime "reconciler.io/runtime/time"
 	"reconciler.io/runtime/validation"
@@ -328,9 +329,9 @@ func TestAggregateReconciler(t *testing.T) {
 					r := defaultAggregateReconciler(c)
 					r.Reconciler = &reconcilers.SyncReconciler[*corev1.ConfigMap]{
 						Sync: func(ctx context.Context, resource *corev1.ConfigMap) error {
-							var key reconcilers.StashKey = "foo"
+							var key stash.Key = "foo"
 							// StashValue will panic if the context is not setup correctly
-							reconcilers.StashValue(ctx, key, "bar")
+							stash.StoreValue(ctx, key, "bar")
 							return nil
 						},
 					}
@@ -626,8 +627,8 @@ func TestAggregateReconciler_Validate(t *testing.T) {
 		{
 			name: "valid reconciler",
 			reconciler: &reconcilers.AggregateReconciler[*resources.TestResource]{
-				Type:       &resources.TestResource{},
-				Request:    req,
+				Type:    &resources.TestResource{},
+				Request: req,
 				Reconciler: &reconcilers.SyncReconciler[*resources.TestResource]{
 					Sync: func(ctx context.Context, resource *resources.TestResource) error {
 						return nil
@@ -650,7 +651,7 @@ func TestAggregateReconciler_Validate(t *testing.T) {
 				AggregateObjectManager: &reconcilers.UpdatingObjectManager[*resources.TestResource]{},
 			},
 			validateNested: true,
-			shouldErr: `AggregateReconciler "TestResourceAggregateReconciler" must have a valid Reconciler: SyncReconciler "SyncReconciler" must implement Sync or SyncWithResult`,
+			shouldErr:      `AggregateReconciler "TestResourceAggregateReconciler" must have a valid Reconciler: SyncReconciler "SyncReconciler" must implement Sync or SyncWithResult`,
 		},
 	}
 

--- a/reconcilers/alias.go
+++ b/reconcilers/alias.go
@@ -17,6 +17,7 @@ limitations under the License.
 package reconcilers
 
 import (
+	"reconciler.io/runtime/stash"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -26,3 +27,20 @@ type Builder = builder.Builder
 type Manager = manager.Manager
 type Request = reconcile.Request
 type Result = reconcile.Result
+
+var WithStash = stash.WithContext
+var StashValue = stash.StoreValue
+var RetrieveValue = stash.RetrieveValue
+var HasValue = stash.HasValue
+var ClearValue = stash.ClearValue
+var ErrStashValueNotFound = stash.ErrValueNotFound
+var ErrStashValueNotAssignable = stash.ErrValueNotAssignable
+
+type StashKey = stash.Key
+type Stasher[T any] = stash.Stasher[T]
+
+// NewStasher creates a stasher for the value type
+func NewStasher[T any](key stash.Key) stash.Stasher[T] {
+	// TODO switch to an alias once generic functions can be aliased
+	return stash.New[T](key)
+}

--- a/reconcilers/childset.go
+++ b/reconcilers/childset.go
@@ -27,6 +27,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"reconciler.io/runtime/internal"
+	"reconciler.io/runtime/stash"
 	"reconciler.io/runtime/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -407,11 +408,11 @@ func (r *ChildSetResult[T]) AggregateError() error {
 	return utilerrors.NewAggregate(errs)
 }
 
-func childSetResultStasher[T client.Object]() Stasher[ChildSetResult[T]] {
-	return NewStasher[ChildSetResult[T]]("reconciler.io/runtime:childSetResult")
+func childSetResultStasher[T client.Object]() stash.Stasher[ChildSetResult[T]] {
+	return stash.New[ChildSetResult[T]]("reconciler.io/runtime:childSetResult")
 }
 
-const knownChildrenStashKey StashKey = "reconciler.io/runtime:knownChildren"
+const knownChildrenStashKey stash.Key = "reconciler.io/runtime:knownChildren"
 
 // RetrieveKnownChildren returns a copy of the children managed by current ChildSetReconciler. The
 // known children can be returned from the DesiredChildren method to preserve existing children, or

--- a/reconcilers/flow.go
+++ b/reconcilers/flow.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/utils/ptr"
+	"reconciler.io/runtime/stash"
 	"reconciler.io/runtime/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -164,7 +165,7 @@ func (err *ErrMaxIterations) Error() string {
 	return fmt.Sprintf("exceeded max iterations: %d", err.Iterations)
 }
 
-const iterationStashKey StashKey = "reconciler.io/runtime:iteration"
+const iterationStashKey stash.Key = "reconciler.io/runtime:iteration"
 
 func stashIteration(ctx context.Context, i int) context.Context {
 	return context.WithValue(ctx, iterationStashKey, i)
@@ -426,11 +427,11 @@ type Cursor[I any] struct {
 }
 
 // CursorStasher creates a Stasher for a Cursor of the generic type
-func CursorStasher[I any]() Stasher[Cursor[I]] {
+func CursorStasher[I any]() stash.Stasher[Cursor[I]] {
 	// avoid key collisions for nested iteration over different types
 	var empty I
-	key := StashKey(fmt.Sprintf("reconciler.io/runtime:cursor:%s", typeName(empty)))
-	return NewStasher[Cursor[I]](key)
+	key := stash.Key(fmt.Sprintf("reconciler.io/runtime:cursor:%s", typeName(empty)))
+	return stash.New[Cursor[I]](key)
 }
 
 // TryCatch facilitates recovery from errors encountered within the Try

--- a/reconcilers/objectmanager_test.go
+++ b/reconcilers/objectmanager_test.go
@@ -38,6 +38,7 @@ import (
 	"reconciler.io/runtime/internal/resources"
 	"reconciler.io/runtime/internal/resources/dies"
 	"reconciler.io/runtime/reconcilers"
+	"reconciler.io/runtime/stash"
 	rtesting "reconciler.io/runtime/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -112,11 +113,11 @@ func TestUpdatingObjectManager(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  givenConfigMap.DieReleasePtr(),
 				desiredStashKey: desiredConfigMap.DieReleasePtr(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: givenConfigMap.DieReleasePtr(),
 			},
 		},
@@ -125,7 +126,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  nil,
 				desiredStashKey: desiredConfigMap.DieReleasePtr(),
 			},
@@ -135,7 +136,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			ExpectCreates: []client.Object{
 				desiredConfigMap,
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: desiredConfigMap.DieReleasePtr(),
 			},
 		},
@@ -144,7 +145,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  diecorev1.ConfigMapBlank.DieDefaultTypeMetadata().DieReleasePtr(),
 				desiredStashKey: desiredConfigMap.DieReleasePtr(),
 			},
@@ -154,7 +155,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			ExpectCreates: []client.Object{
 				desiredConfigMap,
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: desiredConfigMap.DieReleasePtr(),
 			},
 		},
@@ -163,7 +164,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  nil,
 				desiredStashKey: desiredConfigMap.DieReleasePtr(),
 			},
@@ -177,7 +178,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			ExpectCreates: []client.Object{
 				desiredConfigMap,
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: nil,
 			},
 		},
@@ -186,7 +187,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: givenConfigMap.
 					AddData("foo", "bar").
 					DieReleasePtr(),
@@ -198,7 +199,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			ExpectUpdates: []client.Object{
 				desiredConfigMap,
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: desiredConfigMap.DieReleasePtr(),
 			},
 		},
@@ -207,7 +208,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: givenConfigMap.
 					AddData("foo", "bar").
 					DieReleasePtr(),
@@ -223,7 +224,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			ExpectUpdates: []client.Object{
 				desiredConfigMap,
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: nil,
 			},
 		},
@@ -232,7 +233,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: givenConfigMap.
 					AddData("foo", "bar").
 					DieReleasePtr(),
@@ -244,7 +245,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			ExpectDeletes: []rtesting.DeleteRef{
 				rtesting.NewDeleteRefFromObject(givenConfigMap, scheme),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: nil,
 			},
 		},
@@ -253,7 +254,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: givenConfigMap.
 					AddData("foo", "bar").
 					DieReleasePtr(),
@@ -269,7 +270,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 			ExpectDeletes: []rtesting.DeleteRef{
 				rtesting.NewDeleteRefFromObject(givenConfigMap, scheme),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: nil,
 			},
 		},
@@ -284,11 +285,11 @@ func TestUpdatingObjectManager(t *testing.T) {
 					withFinalizer(testFinalizer),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  givenConfigMap.DieReleasePtr(),
 				desiredStashKey: desiredConfigMap.DieReleasePtr(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: givenConfigMap.DieReleasePtr(),
 			},
 		},
@@ -299,7 +300,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 					withFinalizer(testFinalizer),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  givenConfigMap.DieReleasePtr(),
 				desiredStashKey: desiredConfigMap.DieReleasePtr(),
 			},
@@ -323,7 +324,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 					Patch:       []byte(`{"metadata":{"finalizers":["test-finalizer"],"resourceVersion":"999"}}`),
 				},
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: givenConfigMap.DieReleasePtr(),
 			},
 		},
@@ -338,7 +339,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 					withFinalizer(testFinalizer),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  nil,
 				desiredStashKey: nil,
 			},
@@ -362,7 +363,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 					Patch:       []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
 				},
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: nil,
 			},
 		},
@@ -373,14 +374,14 @@ func TestUpdatingObjectManager(t *testing.T) {
 					withTrackDesired(true),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  givenConfigMap.DieReleasePtr(),
 				desiredStashKey: desiredConfigMap.DieReleasePtr(),
 			},
 			ExpectTracks: []rtesting.TrackRequest{
 				rtesting.NewTrackRequest(givenConfigMap, resource, scheme),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: givenConfigMap.DieReleasePtr(),
 			},
 		},
@@ -391,7 +392,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 					withTrackDesired(true),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: nil,
 				desiredStashKey: desiredConfigMap.
 					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
@@ -413,7 +414,7 @@ func TestUpdatingObjectManager(t *testing.T) {
 						d.GenerateName(testName + "-")
 					}),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: desiredConfigMap.
 					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 						d.Name(testName + "-001")
@@ -434,14 +435,14 @@ func TestUpdatingObjectManager(t *testing.T) {
 					}),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: givenConfigMap.
 					Immutable(ptr.To[bool](true)).
 					AddData("foo", "bar").
 					DieReleasePtr(),
 				desiredStashKey: desiredConfigMap.DieReleasePtr(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: givenConfigMap.
 					Immutable(ptr.To[bool](true)).
 					AddData("foo", "bar").
@@ -532,11 +533,11 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  givenTestDuck.DieReleasePtr(),
 				desiredStashKey: desiredTestDuck.DieReleasePtr(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: givenTestDuck.DieReleasePtr(),
 			},
 		},
@@ -545,7 +546,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  nil,
 				desiredStashKey: desiredTestDuck.DieReleasePtr(),
 			},
@@ -555,7 +556,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			ExpectCreates: []client.Object{
 				desiredTestDuck.DieReleaseUnstructured(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: desiredTestDuck.DieReleasePtr(),
 			},
 		},
@@ -564,7 +565,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  dies.TestDuckBlank.APIVersion("example.com").Kind("Test").DieReleasePtr(),
 				desiredStashKey: desiredTestDuck.DieReleasePtr(),
 			},
@@ -574,7 +575,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			ExpectCreates: []client.Object{
 				desiredTestDuck.DieReleaseUnstructured(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: desiredTestDuck.DieReleasePtr(),
 			},
 		},
@@ -583,7 +584,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  nil,
 				desiredStashKey: desiredTestDuck.DieReleasePtr(),
 			},
@@ -597,7 +598,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			ExpectCreates: []client.Object{
 				desiredTestDuck.DieReleaseUnstructured(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: nil,
 			},
 		},
@@ -606,7 +607,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: givenTestDuck.
 					SpecDie(func(d *dies.TestDuckSpecDie) {
 						d.AddField("foo", "bar")
@@ -620,7 +621,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			ExpectUpdates: []client.Object{
 				desiredTestDuck.DieReleaseUnstructured(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: desiredTestDuck.DieReleasePtr(),
 			},
 		},
@@ -629,7 +630,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: givenTestDuck.
 					SpecDie(func(d *dies.TestDuckSpecDie) {
 						d.AddField("foo", "bar")
@@ -647,7 +648,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			ExpectUpdates: []client.Object{
 				desiredTestDuck.DieReleaseUnstructured(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: nil,
 			},
 		},
@@ -656,7 +657,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: givenTestDuck.
 					SpecDie(func(d *dies.TestDuckSpecDie) {
 						d.AddField("foo", "bar")
@@ -670,7 +671,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			ExpectDeletes: []rtesting.DeleteRef{
 				rtesting.NewDeleteRefFromObject(givenTestDuck, scheme),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: nil,
 			},
 		},
@@ -679,7 +680,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			Metadata: map[string]any{
 				"ObjectManager": makeUpdatingObjectManager(),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: givenTestDuck.
 					SpecDie(func(d *dies.TestDuckSpecDie) {
 						d.AddField("foo", "bar")
@@ -697,7 +698,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 			ExpectDeletes: []rtesting.DeleteRef{
 				rtesting.NewDeleteRefFromObject(givenTestDuck, scheme),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: nil,
 			},
 		},
@@ -712,11 +713,11 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 					withFinalizer(testFinalizer),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  givenTestDuck.DieReleasePtr(),
 				desiredStashKey: desiredTestDuck.DieReleasePtr(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: givenTestDuck.DieReleasePtr(),
 			},
 		},
@@ -727,7 +728,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 					withFinalizer(testFinalizer),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  givenTestDuck.DieReleasePtr(),
 				desiredStashKey: desiredTestDuck.DieReleasePtr(),
 			},
@@ -751,7 +752,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 					Patch:       []byte(`{"metadata":{"finalizers":["test-finalizer"],"resourceVersion":"999"}}`),
 				},
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: givenTestDuck.DieReleasePtr(),
 			},
 		},
@@ -766,7 +767,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 					withFinalizer(testFinalizer),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  nil,
 				desiredStashKey: nil,
 			},
@@ -790,7 +791,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 					Patch:       []byte(`{"metadata":{"finalizers":null,"resourceVersion":"999"}}`),
 				},
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: nil,
 			},
 		},
@@ -801,14 +802,14 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 					withTrackDesired(true),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey:  givenTestDuck.DieReleasePtr(),
 				desiredStashKey: desiredTestDuck.DieReleasePtr(),
 			},
 			ExpectTracks: []rtesting.TrackRequest{
 				rtesting.NewTrackRequest(givenTestDuck, resource, scheme),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: givenTestDuck.DieReleasePtr(),
 			},
 		},
@@ -819,7 +820,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 					withTrackDesired(true),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: nil,
 				desiredStashKey: desiredTestDuck.
 					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
@@ -842,7 +843,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 					}).
 					DieReleaseUnstructured(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: desiredTestDuck.
 					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 						d.Name(testName + "-001")
@@ -863,7 +864,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 					}),
 				),
 			},
-			GivenStashedValues: map[reconcilers.StashKey]any{
+			GivenStashedValues: map[stash.Key]any{
 				actualStashKey: givenTestDuck.
 					SpecDie(func(d *dies.TestDuckSpecDie) {
 						d.Immutable(ptr.To[bool](true))
@@ -872,7 +873,7 @@ func TestUpdatingObjectManager_Duck(t *testing.T) {
 					DieReleasePtr(),
 				desiredStashKey: desiredTestDuck.DieReleasePtr(),
 			},
-			ExpectStashedValues: map[reconcilers.StashKey]interface{}{
+			ExpectStashedValues: map[stash.Key]interface{}{
 				resultStashKey: givenTestDuck.
 					SpecDie(func(d *dies.TestDuckSpecDie) {
 						d.Immutable(ptr.To[bool](true))

--- a/reconcilers/reconcilers.go
+++ b/reconcilers/reconcilers.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"reconciler.io/runtime/stash"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,12 +57,12 @@ var (
 	ErrHaltSubReconcilers = fmt.Errorf("stop processing SubReconcilers, without returning an error: %w", ErrQuiet)
 )
 
-const requestStashKey StashKey = "reconciler.io/runtime:request"
-const configStashKey StashKey = "reconciler.io/runtime:config"
-const originalConfigStashKey StashKey = "reconciler.io/runtime:originalConfig"
-const resourceTypeStashKey StashKey = "reconciler.io/runtime:resourceType"
-const originalResourceTypeStashKey StashKey = "reconciler.io/runtime:originalResourceType"
-const additionalConfigsStashKey StashKey = "reconciler.io/runtime:additionalConfigs"
+const requestStashKey stash.Key = "reconciler.io/runtime:request"
+const configStashKey stash.Key = "reconciler.io/runtime:config"
+const originalConfigStashKey stash.Key = "reconciler.io/runtime:originalConfig"
+const resourceTypeStashKey stash.Key = "reconciler.io/runtime:resourceType"
+const originalResourceTypeStashKey stash.Key = "reconciler.io/runtime:originalResourceType"
+const additionalConfigsStashKey stash.Key = "reconciler.io/runtime:additionalConfigs"
 
 func StashRequest(ctx context.Context, req Request) context.Context {
 	return context.WithValue(ctx, requestStashKey, req)

--- a/reconcilers/resource.go
+++ b/reconcilers/resource.go
@@ -40,6 +40,7 @@ import (
 
 	"reconciler.io/runtime/duck"
 	"reconciler.io/runtime/internal"
+	"reconciler.io/runtime/stash"
 	rtime "reconciler.io/runtime/time"
 	"reconciler.io/runtime/validation"
 )
@@ -264,7 +265,7 @@ func (r *ResourceReconciler[T]) Validate(ctx context.Context) error {
 func (r *ResourceReconciler[T]) Reconcile(ctx context.Context, req Request) (Result, error) {
 	r.init()
 
-	ctx = WithStash(ctx)
+	ctx = stash.WithContext(ctx)
 
 	c := r.Config
 

--- a/reconcilers/resource_test.go
+++ b/reconcilers/resource_test.go
@@ -35,6 +35,7 @@ import (
 	"reconciler.io/runtime/internal/resources"
 	"reconciler.io/runtime/internal/resources/dies"
 	"reconciler.io/runtime/reconcilers"
+	"reconciler.io/runtime/stash"
 	rtesting "reconciler.io/runtime/testing"
 	rtime "reconciler.io/runtime/time"
 	"reconciler.io/runtime/validation"
@@ -696,9 +697,9 @@ func TestResourceReconciler_Duck(t *testing.T) {
 				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestDuck] {
 					return &reconcilers.SyncReconciler[*resources.TestDuck]{
 						Sync: func(ctx context.Context, resource *resources.TestDuck) error {
-							var key reconcilers.StashKey = "foo"
-							// StashValue will panic if the context is not setup correctly
-							reconcilers.StashValue(ctx, key, "bar")
+							var key stash.Key = "foo"
+							// StoreValue will panic if the context is not setup correctly
+							stash.StoreValue(ctx, key, "bar")
 							return nil
 						},
 					}
@@ -1206,9 +1207,9 @@ func TestResourceReconciler(t *testing.T) {
 				"SubReconciler": func(t *testing.T, c reconcilers.Config) reconcilers.SubReconciler[*resources.TestResource] {
 					return &reconcilers.SyncReconciler[*resources.TestResource]{
 						Sync: func(ctx context.Context, resource *resources.TestResource) error {
-							var key reconcilers.StashKey = "foo"
-							// StashValue will panic if the context is not setup correctly
-							reconcilers.StashValue(ctx, key, "bar")
+							var key stash.Key = "foo"
+							// StoreValue will panic if the context is not setup correctly
+							stash.StoreValue(ctx, key, "bar")
 							return nil
 						},
 					}

--- a/reconcilers/webhook.go
+++ b/reconcilers/webhook.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"reconciler.io/runtime/internal"
+	"reconciler.io/runtime/stash"
 	rtime "reconciler.io/runtime/time"
 	"reconciler.io/runtime/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -174,7 +175,7 @@ func (r *AdmissionWebhookAdapter[T]) withContext(ctx context.Context) context.Co
 		WithName(r.Name)
 	ctx = logr.NewContext(ctx, log)
 
-	ctx = WithStash(ctx)
+	ctx = stash.WithContext(ctx)
 
 	ctx = StashConfig(ctx, r.Config)
 	ctx = StashOriginalConfig(ctx, r.Config)
@@ -287,9 +288,9 @@ func (r *AdmissionWebhookAdapter[T]) reconcile(ctx context.Context, req admissio
 }
 
 const (
-	admissionRequestStashKey  StashKey = "reconciler.io/runtime:admission-request"
-	admissionResponseStashKey StashKey = "reconciler.io/runtime:admission-response"
-	httpRequestStashKey       StashKey = "reconciler.io/runtime:http-request"
+	admissionRequestStashKey  stash.Key = "reconciler.io/runtime:admission-request"
+	admissionResponseStashKey stash.Key = "reconciler.io/runtime:admission-response"
+	httpRequestStashKey       stash.Key = "reconciler.io/runtime:http-request"
 )
 
 func StashAdmissionRequest(ctx context.Context, req admission.Request) context.Context {

--- a/reconcilers/webhook_test.go
+++ b/reconcilers/webhook_test.go
@@ -38,6 +38,7 @@ import (
 	"reconciler.io/runtime/internal/resources"
 	"reconciler.io/runtime/internal/resources/dies"
 	"reconciler.io/runtime/reconcilers"
+	"reconciler.io/runtime/stash"
 	rtesting "reconciler.io/runtime/testing"
 	"reconciler.io/runtime/tracker"
 	"reconciler.io/runtime/validation"
@@ -321,8 +322,8 @@ func TestAdmissionWebhookAdapter(t *testing.T) {
 					return reconcilers.Sequence[*resources.TestResource]{
 						&reconcilers.SyncReconciler[*resources.TestResource]{
 							Sync: func(ctx context.Context, _ *resources.TestResource) error {
-								// StashValue will panic if context is not setup for stashing
-								reconcilers.StashValue(ctx, reconcilers.StashKey("greeting"), "hello")
+								// StoreValue will panic if context is not setup for stashing
+								stash.StoreValue(ctx, stash.Key("greeting"), "hello")
 
 								return nil
 							},
@@ -330,7 +331,7 @@ func TestAdmissionWebhookAdapter(t *testing.T) {
 						&reconcilers.SyncReconciler[*resources.TestResource]{
 							Sync: func(ctx context.Context, _ *resources.TestResource) error {
 								// StashValue will panic if context is not setup for stashing
-								greeting := reconcilers.RetrieveValue(ctx, reconcilers.StashKey("greeting"))
+								greeting := stash.RetrieveValue(ctx, stash.Key("greeting"))
 								if greeting != "hello" {
 									t.Errorf("unexpected stash value retrieved")
 								}
@@ -352,7 +353,7 @@ func TestAdmissionWebhookAdapter(t *testing.T) {
 				AdmissionResponse: response.DieRelease(),
 			},
 			Prepare: func(t *testing.T, ctx context.Context, tc *rtesting.AdmissionWebhookTestCase) (context.Context, error) {
-				key := reconcilers.StashKey("test-key")
+				key := stash.Key("test-key")
 				value := "test-value"
 				ctx = context.WithValue(ctx, key, value)
 

--- a/stash/stash_test.go
+++ b/stash/stash_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package reconcilers
+package stash
 
 import (
 	"testing"
@@ -46,11 +46,11 @@ func TestStash(t *testing.T) {
 		},
 	}
 
-	var key StashKey = "stash-key"
-	ctx := WithStash(context.Background())
+	var key Key = "stash-key"
+	ctx := WithContext(context.Background())
 	for _, c := range tests {
 		t.Run(c.name, func(t *testing.T) {
-			StashValue(ctx, key, c.value)
+			StoreValue(ctx, key, c.value)
 			if expected, actual := c.value, RetrieveValue(ctx, key); !equality.Semantic.DeepEqual(expected, actual) {
 				t.Errorf("%s: unexpected stash value, actually = %v, expected = %v", c.name, actual, expected)
 			}
@@ -60,7 +60,7 @@ func TestStash(t *testing.T) {
 
 func TestStash_StashValue_UndecoratedContext(t *testing.T) {
 	ctx := context.Background()
-	var key StashKey = "stash-key"
+	var key Key = "stash-key"
 	value := "value"
 
 	defer func() {
@@ -68,12 +68,12 @@ func TestStash_StashValue_UndecoratedContext(t *testing.T) {
 			t.Error("expected StashValue() to panic")
 		}
 	}()
-	StashValue(ctx, key, value)
+	StoreValue(ctx, key, value)
 }
 
 func TestStash_RetrieveValue_UndecoratedContext(t *testing.T) {
 	ctx := context.Background()
-	var key StashKey = "stash-key"
+	var key Key = "stash-key"
 
 	defer func() {
 		if r := recover(); r == nil {
@@ -84,8 +84,8 @@ func TestStash_RetrieveValue_UndecoratedContext(t *testing.T) {
 }
 
 func TestStash_RetrieveValue_Undefined(t *testing.T) {
-	ctx := WithStash(context.Background())
-	var key StashKey = "stash-key"
+	ctx := WithContext(context.Background())
+	var key Key = "stash-key"
 
 	if value := RetrieveValue(ctx, key); value != nil {
 		t.Error("expected RetrieveValue() to return nil for undefined key")
@@ -93,11 +93,11 @@ func TestStash_RetrieveValue_Undefined(t *testing.T) {
 }
 
 func TestStasher(t *testing.T) {
-	ctx := WithStash(context.Background())
-	stasher := NewStasher[string]("my-key")
+	ctx := WithContext(context.Background())
+	stasher := New[string]("my-key")
 
-	if key := stasher.Key(); key != StashKey("my-key") {
-		t.Errorf("expected key to be %q got %q", StashKey("my-key"), key)
+	if key := stasher.Key(); key != Key("my-key") {
+		t.Errorf("expected key to be %q got %q", Key("my-key"), key)
 	}
 
 	t.Run("no value", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestStasher(t *testing.T) {
 		if value := stasher.RetrieveOrEmpty(ctx); value != "hello world" {
 			t.Errorf("expected value to be %q got %q", "hello world", value)
 		}
-		altCtx := WithStash(context.Background())
+		altCtx := WithContext(context.Background())
 		if value := stasher.RetrieveOrEmpty(altCtx); value != "" {
 			t.Error("expected value to be empty")
 		}

--- a/testing/diff.go
+++ b/testing/diff.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"reconciler.io/runtime/reconcilers"
+	"reconciler.io/runtime/stash"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -32,7 +33,7 @@ type Differ interface {
 	PatchRef(expected, actual PatchRef) string
 	DeleteRef(expected, actual DeleteRef) string
 	DeleteCollectionRef(expected, actual DeleteCollectionRef) string
-	StashedValue(expected, actual any, key reconcilers.StashKey) string
+	StashedValue(expected, actual any, key stash.Key) string
 	Resource(expected, actual client.Object) string
 	ResourceStatusUpdate(expected, actual client.Object) string
 	ResourceUpdate(expected, actual client.Object) string
@@ -74,7 +75,7 @@ func (*differ) DeleteCollectionRef(expected, actual DeleteCollectionRef) string 
 	return cmp.Diff(expected, actual, NormalizeLabelSelector, NormalizeFieldSelector)
 }
 
-func (*differ) StashedValue(expected, actual any, key reconcilers.StashKey) string {
+func (*differ) StashedValue(expected, actual any, key stash.Key) string {
 	return cmp.Diff(expected, actual, reconcilers.IgnoreAllUnexported,
 		IgnoreLastTransitionTime,
 		IgnoreTypeMeta,

--- a/testing/diff_test.go
+++ b/testing/diff_test.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"reconciler.io/runtime/reconcilers"
+	"reconciler.io/runtime/stash"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -54,7 +55,7 @@ func (d *staticDiffer) DeleteCollectionRef(expected, actual DeleteCollectionRef)
 	return d.diff
 }
 
-func (d *staticDiffer) StashedValue(expected, actual any, key reconcilers.StashKey) string {
+func (d *staticDiffer) StashedValue(expected, actual any, key stash.Key) string {
 	return d.diff
 }
 

--- a/testing/objectmanager.go
+++ b/testing/objectmanager.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"reconciler.io/runtime/internal"
 	"reconciler.io/runtime/reconcilers"
+	"reconciler.io/runtime/stash"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -147,14 +148,14 @@ func (h *ObjectManagerReconcilerTestHarness[T]) Reconcile(ctx context.Context, r
 	return reconcilers.Result{}, err
 }
 
-func ObjectManagerReconcilerTestHarnessActualStasher[T client.Object]() reconcilers.Stasher[T] {
-	return reconcilers.NewStasher[T]("reconciler.io/object-manager-reconciler-test-harness-actual")
+func ObjectManagerReconcilerTestHarnessActualStasher[T client.Object]() stash.Stasher[T] {
+	return stash.New[T]("reconciler.io/object-manager-reconciler-test-harness-actual")
 }
 
-func ObjectManagerReconcilerTestHarnessDesiredStasher[T client.Object]() reconcilers.Stasher[T] {
-	return reconcilers.NewStasher[T]("reconciler.io/object-manager-reconciler-test-harness-desired")
+func ObjectManagerReconcilerTestHarnessDesiredStasher[T client.Object]() stash.Stasher[T] {
+	return stash.New[T]("reconciler.io/object-manager-reconciler-test-harness-desired")
 }
 
-func ObjectManagerReconcilerTestHarnessResultStasher[T client.Object]() reconcilers.Stasher[T] {
-	return reconcilers.NewStasher[T]("reconciler.io/object-manager-reconciler-test-harness-result")
+func ObjectManagerReconcilerTestHarnessResultStasher[T client.Object]() stash.Stasher[T] {
+	return stash.New[T]("reconciler.io/object-manager-reconciler-test-harness-result")
 }

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"reconciler.io/runtime/reconcilers"
+	"reconciler.io/runtime/stash"
 	rtime "reconciler.io/runtime/time"
 	"reconciler.io/runtime/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -130,7 +131,7 @@ type ReconcilerTestCase struct {
 type VerifyFunc func(t *testing.T, result reconcilers.Result, err error)
 
 // VerifyStashedValueFunc is a verification function for the entries in the stash
-type VerifyStashedValueFunc func(t *testing.T, key reconcilers.StashKey, expected, actual interface{})
+type VerifyStashedValueFunc func(t *testing.T, key stash.Key, expected, actual interface{})
 
 // ReconcilerTests represents a map of reconciler test cases. The map key is the name of each test
 // case. Test cases are executed in random order.

--- a/testing/webhook.go
+++ b/testing/webhook.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"reconciler.io/runtime/reconcilers"
+	"reconciler.io/runtime/stash"
 	rtime "reconciler.io/runtime/time"
 	"reconciler.io/runtime/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -169,7 +170,7 @@ func (tc *AdmissionWebhookTestCase) RunWithContext(t *testing.T, scheme *runtime
 		t.SkipNow()
 	}
 
-	ctx := reconcilers.WithStash(context.Background())
+	ctx := stash.WithContext(context.Background())
 	if tc.Now == (time.Time{}) {
 		tc.Now = time.Now()
 	}


### PR DESCRIPTION
The existing types/names are aliased back into the reconcilers package to preserve compatibility.

Symbol names in the new package have evolved slightly to avoid redundancy:

- `StashKey` -> `Key`
- `NewStasher` -> `New`
- `WithStash` -> `WithContext`
- `StashValue` -> `StoreValue`
- `ErrStashValueNotFound` -> `ErrValueNotFound`
- `ErrStashValueNotAssignable` -> `ErrValueNotAssignable`

Resolves #591 