### PR TITLE
Minor fixes

### DIFF
--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -121,7 +121,7 @@ type ReconcilerTestCase struct {
 	// execution, or to make assertions for mocks.
 	CleanUp func(t *testing.T, ctx context.Context, tc *ReconcilerTestCase) error
 	// Now is the time the test should run as, defaults to the current time. This value can be used
-	// by reconcilers via the reconcilers.RetireveNow(ctx) method.
+	// by reconcilers via the reconcilers.RetrieveNow(ctx) method.
 	Now time.Time
 	// Differ methods to use to compare expected and actual values. An empty string is returned for equivalent items.
 	Differ Differ

--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -159,7 +159,7 @@ func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory 
 	}
 
 	ctx := context.Background()
-	if tc.Now == (time.Time{}) {
+	if tc.Now.IsZero() {
 		tc.Now = time.Now()
 	}
 	ctx = rtime.StashNow(ctx, tc.Now)

--- a/testing/reconciler_test.go
+++ b/testing/reconciler_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"reconciler.io/runtime/reconcilers"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcilerTestCase_Run(t *testing.T) {
+	type testCase struct {
+		name      string
+		verify    func(*testing.T, *ReconcilerTestCase, *testCase)
+		verifyRan bool
+	}
+	tests := []*testCase{
+		{
+			name: "Now defaults to time.Now()",
+			verify: func(t *testing.T, rtc *ReconcilerTestCase, tc *testCase) {
+				tc.verifyRan = true
+				if rtc.Now.IsZero() {
+					t.Error("expected test case to be initialized with time.Now()")
+				}
+
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rtc := &ReconcilerTestCase{}
+			if tc.verify != nil {
+				rtc.Prepare = func(t *testing.T, ctx context.Context, rtc *ReconcilerTestCase) (context.Context, error) {
+					tc.verify(t, rtc, tc)
+					return ctx, nil
+				}
+			}
+			rtc.Run(t, runtime.NewScheme(), func(t *testing.T, rtc *ReconcilerTestCase, c reconcilers.Config) reconcile.Reconciler {
+				return reconcile.Func(func(ctx context.Context, o reconcile.Request) (reconcile.Result, error) {
+					return reconcile.Result{}, nil
+				})
+			})
+
+			if !tc.verifyRan {
+				t.Fatal("expected verify to have run")
+			}
+		})
+	}
+}

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -168,7 +168,7 @@ func (tc *SubReconcilerTestCase[T]) Run(t *testing.T, scheme *runtime.Scheme, fa
 	}
 
 	ctx := stash.WithContext(context.Background())
-	if tc.Now == (time.Time{}) {
+	if tc.Now.IsZero() {
 		tc.Now = time.Now()
 	}
 	ctx = rtime.StashNow(ctx, tc.Now)

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -131,7 +131,7 @@ type SubReconcilerTestCase[Type client.Object] struct {
 	// execution, or to make assertions for mocks.
 	CleanUp func(t *testing.T, ctx context.Context, tc *SubReconcilerTestCase[Type]) error
 	// Now is the time the test should run as, defaults to the current time. This value can be used
-	// by reconcilers via the reconcilers.RetireveNow(ctx) method.
+	// by reconcilers via the reconcilers.RetrieveNow(ctx) method.
 	Now time.Time
 	// Differ methods to use to compare expected and actual values. An empty string is returned for equivalent items.
 	Differ Differ

--- a/testing/webhook.go
+++ b/testing/webhook.go
@@ -119,7 +119,7 @@ type AdmissionWebhookTestCase struct {
 	// execution, or to make assertions for mocks.
 	CleanUp func(t *testing.T, ctx context.Context, tc *AdmissionWebhookTestCase) error
 	// Now is the time the test should run as, defaults to the current time. This value can be used
-	// by reconcilers via the reconcilers.RetireveNow(ctx) method.
+	// by reconcilers via the reconcilers.RetrieveNow(ctx) method.
 	Now time.Time
 	// Differ methods to use to compare expected and actual values. An empty string is returned for equivalent items.
 	Differ Differ


### PR DESCRIPTION
While upgrading one of our projects to the latest release I came across a few nits in the code and decided to put them into a separate branch and open a PR.

1. The `RetrieveNow` method is misspelled across 3 comments so it was probably copy'n'pasted.
2. In `tc.Now == (time.Time{})` linters suggest to use `time.Equal` instead but what's really tested here is whether an explicit time has been set or not so checking `time.Now.IsZero()` looks like the prudent thing to do. I couldn't find unit tests for the testing facilities so I added one for this. I can of course also remove this again.

Thank you for your hard work, using this library has started to improve our operators massively.