### PR TITLE
Fix broken test suites

### DIFF
--- a/testing/reconciler.go
+++ b/testing/reconciler.go
@@ -214,6 +214,10 @@ func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory 
 		ExpectStatusPatches:     tc.ExpectStatusPatches,
 	}
 
+	c := expectConfig.Config()
+	ctx = reconcilers.StashConfig(ctx, c)
+	ctx = reconcilers.StashOriginalConfig(ctx, c)
+
 	configs := make(map[string]reconcilers.Config, len(tc.AdditionalConfigs))
 	for k, v := range tc.AdditionalConfigs {
 		v.Name = k
@@ -221,7 +225,7 @@ func (tc *ReconcilerTestCase) Run(t *testing.T, scheme *runtime.Scheme, factory 
 	}
 	ctx = reconcilers.StashAdditionalConfigs(ctx, configs)
 
-	r := factory(t, tc, expectConfig.Config())
+	r := factory(t, tc, c)
 	ctx = validation.WithRecursive(ctx)
 	if v, ok := r.(validation.Validator); ok {
 		if err := v.Validate(ctx); err != nil {

--- a/testing/subreconciler.go
+++ b/testing/subreconciler.go
@@ -244,6 +244,9 @@ func (tc *SubReconcilerTestCase[T]) Run(t *testing.T, scheme *runtime.Scheme, fa
 	}
 	c := expectConfig.Config()
 
+	ctx = reconcilers.StashConfig(ctx, c)
+	ctx = reconcilers.StashOriginalConfig(ctx, c)
+
 	r := factory(t, tc, c)
 	ctx = validation.WithRecursive(ctx)
 	if v, ok := r.(validation.Validator); ok {
@@ -258,9 +261,6 @@ func (tc *SubReconcilerTestCase[T]) Run(t *testing.T, scheme *runtime.Scheme, fa
 		}
 		stash.StoreValue(ctx, k, v)
 	}
-
-	ctx = reconcilers.StashConfig(ctx, c)
-	ctx = reconcilers.StashOriginalConfig(ctx, c)
 
 	resource := tc.Resource.DeepCopyObject().(T)
 	if resource.GetResourceVersion() == "" {


### PR DESCRIPTION
https://github.com/reconcilerio/runtime/commit/e07a96cab7cd1a429954e65f569c6b75b1cd8426#diff-ced16713406a9137f85f9e4b12a81ca15c3196b57eaa12ab71dfbb3cb82d7037R149-R157 broke all unit tests because validation would run in https://github.com/reconcilerio/runtime/blob/main/testing/reconciler.go#L226-L230 and https://github.com/reconcilerio/runtime/blob/main/testing/subreconciler.go#L249-L253 but the context wouldn’t contain a stashed config.

Here are the test failures from our local suite:

```
=== FAIL: internal/controller/operators TestClusterReconciler (0.00s)
panic: config must exist on the context. Check that the context is from a ResourceReconciler or WithConfig [recovered]
        panic: config must exist on the context. Check that the context is from a ResourceReconciler or WithConfig

goroutine 72 [running]:
testing.tRunner.func1.2({0x103bbb480, 0x14000907630})
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1734 +0x1ac
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1737 +0x334
panic({0x103bbb480?, 0x14000907630?})
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/runtime/panic.go:792 +0x124
reconciler.io/runtime/reconcilers.RetrieveConfigOrDie(...)
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/reconcilers/reconcilers.go:97
reconciler.io/runtime/reconcilers.(*UpdatingObjectManager[...]).Validate(0x103ed0180, {0x103eba658, 0x140004952c0?})
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/reconcilers/objectmanager.go:157 +0x18c
reconciler.io/runtime/reconcilers.(*ChildSetReconciler[...]).Validate(0x1020bd588, {0x103eba658?, 0x140004952c0})
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/reconcilers/childset.go:298 +0x2b0
reconciler.io/runtime/reconcilers.(*Sequence[...]).Validate(0x103530550, {0x103eba658?, 0x140004952c0})
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/reconcilers/sequence.go:72 +0xcc
reconciler.io/runtime/reconcilers.(*ResourceReconciler[...]).Validate(0x103ed57e0, {0x103eba658, 0x140004952c0})
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/reconcilers/resource.go:222 +0x564
reconciler.io/runtime/testing.(*ReconcilerTestCase).Run(0x140004d6d88, 0x14000502e00, 0x140005687e0, 0x103e8f380)
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/testing/reconciler.go:227 +0x980
reconciler.io/runtime/testing.ReconcilerTestSuite.Run.func1(0x14000502e00)
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/testing/reconciler.go:280 +0x50
testing.tRunner(0x14000502e00, 0x1400081adc0)
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1792 +0xe4
created by testing.(*T).Run in goroutine 71
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1851 +0x374

...

=== FAIL: internal/subreconcilers TestDownstreamRecordsChildSetReconciler (0.00s)
panic: config must exist on the context. Check that the context is from a ResourceReconciler or WithConfig [recovered]
        panic: config must exist on the context. Check that the context is from a ResourceReconciler or WithConfig

goroutine 315 [running]:
testing.tRunner.func1.2({0x105eea340, 0x1400076e9f0})
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1734 +0x1ac
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1737 +0x334
panic({0x105eea340?, 0x1400076e9f0?})
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/runtime/panic.go:792 +0x124
reconciler.io/runtime/reconcilers.RetrieveConfigOrDie(...)
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/reconcilers/reconcilers.go:97
reconciler.io/runtime/reconcilers.(*UpdatingObjectManager[...]).Validate(0x1061fdc40, {0x1061e8738, 0x14000622d80?})
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/reconcilers/objectmanager.go:157 +0x18c
reconciler.io/runtime/reconcilers.(*ChildSetReconciler[...]).Validate(0x14000715600, {0x1061e8738?, 0x14000622d80})
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/reconcilers/childset.go:298 +0x2b0
reconciler.io/runtime/testing.(*SubReconcilerTestCase[...]).Run(0x1061f7720, 0x1400048afc0, 0x140005cc460, 0x1061bd608)
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/testing/subreconciler.go:250 +0x994
reconciler.io/runtime/testing.SubReconcilerTestSuite[...].Run.func1()
        /Users/annismckenzie/git/go/pkg/mod/reconciler.io/runtime@v0.24.0/testing/subreconciler.go:369 +0x60
testing.tRunner(0x1400048afc0, 0x140004fbd40)
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1792 +0xe4
created by testing.(*T).Run in goroutine 314
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1851 +0x374

DONE 85 tests, 4 failures in 3.122s
```

Stashing the config and the original config (the latter only for consistency because it's done elsewhere in tandem as well) fixed our test suites (at least the panics).