### PR TITLE
More test failures with latest release

### DIFF
--- a/reconcilers/resource.go
+++ b/reconcilers/resource.go
@@ -384,7 +384,11 @@ func (r *ResourceReconciler[T]) reconcileOuter(ctx context.Context, req Request)
 		}
 
 		// Suppress result. Let the informer discover the resource mutation and requeue. Requeueing
-		// now may result in re-processing a stale cache.
+		// now may result in re-processing a stale cache. Honor the requeue after if it was set.
+		if result.RequeueAfter > 0 {
+			return result, nil
+		}
+
 		return Result{}, nil
 	}
 

--- a/reconcilers/resource.go
+++ b/reconcilers/resource.go
@@ -298,6 +298,9 @@ func (r *ResourceReconciler[T]) Reconcile(ctx context.Context, req Request) (Res
 	result, err := r.AfterReconcile(ctx, req, AggregateResults(beforeResult, reconcileResult), err)
 	if errors.Is(err, ErrQuiet) {
 		// suppress error, while forcing a requeue
+		if result.RequeueAfter > 0 { // honor requeue after returned by reconciler
+			return result, nil
+		}
 		return Result{Requeue: true}, nil
 	}
 	return result, err

--- a/reconcilers/resource_test.go
+++ b/reconcilers/resource_test.go
@@ -964,7 +964,7 @@ func TestResourceReconciler(t *testing.T) {
 								resource.Status.Fields = map[string]string{}
 							}
 							resource.Status.Fields["Reconciler"] = "ran"
-							// the result is ignored because the status is updated
+							// the result is honored
 							return reconcilers.Result{RequeueAfter: 10}, nil
 						},
 					}
@@ -973,6 +973,9 @@ func TestResourceReconciler(t *testing.T) {
 			ExpectEvents: []rtesting.Event{
 				rtesting.NewEvent(givenResource, scheme, corev1.EventTypeNormal, "StatusUpdated",
 					`Updated status`),
+			},
+			ExpectedResult: reconcile.Result{
+				RequeueAfter: 10,
 			},
 			ExpectStatusUpdates: []client.Object{
 				givenResource.StatusDie(func(d *dies.TestResourceStatusDie) {


### PR DESCRIPTION
After upgrading to the latest release, more test failures surfaced in our test suites. I tracked those down to changes between v0.23.0 and v.0.24.0.

I'll add some comments in the code as well.