### PR TITLE
Avoid panic with go 1.26 and duck resources

### DIFF
--- a/reconcilers/child.go
+++ b/reconcilers/child.go
@@ -203,12 +203,14 @@ func (r *ChildReconciler[T, CT, CLT]) SetupWithManager(ctx context.Context, mgr 
 		var ct client.Object = r.ChildType
 		if duck.IsDuck(ct, mgr.GetScheme()) {
 			gvk := ct.GetObjectKind().GroupVersionKind()
-			ct = &unstructured.Unstructured{}
-			ct.GetObjectKind().SetGroupVersionKind(gvk)
+			u := &unstructured.Unstructured{}
+			u.GetObjectKind().SetGroupVersionKind(gvk)
+			bldr.Owns(u)
+			bldr.Watches(u, EnqueueTracked(ctx))
+		} else {
+			bldr.Owns(ct)
+			bldr.Watches(ct, EnqueueTracked(ctx))
 		}
-
-		bldr.Owns(ct)
-		bldr.Watches(ct, EnqueueTracked(ctx))
 	}
 
 	if err := r.ChildObjectManager.SetupWithManager(ctx, mgr, bldr); err != nil {

--- a/reconcilers/objectmanager.go
+++ b/reconcilers/objectmanager.go
@@ -143,11 +143,12 @@ func (r *UpdatingObjectManager[T]) SetupWithManager(ctx context.Context, mgr ctr
 		var ct client.Object = r.Type
 		if duck.IsDuck(ct, mgr.GetScheme()) {
 			gvk := ct.GetObjectKind().GroupVersionKind()
-			ct = &unstructured.Unstructured{}
-			ct.GetObjectKind().SetGroupVersionKind(gvk)
+			u := &unstructured.Unstructured{}
+			u.GetObjectKind().SetGroupVersionKind(gvk)
+			bldr.Watches(u, EnqueueTracked(ctx))
+		} else {
+			bldr.Watches(ct, EnqueueTracked(ctx))
 		}
-
-		bldr.Watches(ct, EnqueueTracked(ctx))
 	}
 
 	return nil


### PR DESCRIPTION
A regressions from go 1.25 to 1.26 can cause a panic when a variables is reassigned from a generic to a concrete type even when both types implement the same interface the variable is typed as.

Working around this issue by defining a new variable rather than reassigning an existing var.